### PR TITLE
Add dependency status to the README via Gemnasium

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Enumerize [![TravisCI](https://secure.travis-ci.org/twinslash/enumerize.png?branch=master)](http://travis-ci.org/twinslash/enumerize)
+# Enumerize [![TravisCI](https://secure.travis-ci.org/twinslash/enumerize.png?branch=master)](http://travis-ci.org/twinslash/enumerize) [![Gemnasium](https://gemnasium.com/twinslash/enumerize.png)](https://gemnasium.com/twinslash/enumerize)
 
 Enumerated attributes with I18n and ActiveRecord support
 


### PR DESCRIPTION
Great work on Enumerize. I just saw it on RubyFlow.

Gemnasium is a service to help keep you up to date on when there are new versions of your gem dependencies. You can also find Gemnasium status images on projects like Rails, Rack, Cucumber, Twitter, OmniAuth, etc.
