### PR TITLE
added delegated to object boolean methods

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -1,6 +1,6 @@
 module Enumerize
   class Attribute
-    attr_reader :name, :values, :default_value
+    attr_reader :name, :values, :default_value, :delegate
 
     def initialize(klass, name, options={})
       raise ArgumentError, ':in option is required' unless options[:in]
@@ -9,6 +9,7 @@ module Enumerize
       @name   = name
       @values = Array(options[:in]).map { |v| Value.new(self, v) }
       @value_hash = Hash[@values.map { |v| [v.to_s, v] }]
+      @delegate = options.delete(:delegate)
 
       if options[:default]
         @default_value = options[:default] && find_value(options[:default])

--- a/lib/enumerize/integrations/basic.rb
+++ b/lib/enumerize/integrations/basic.rb
@@ -29,6 +29,19 @@ module Enumerize
             end
           RUBY
 
+          class_eval <<-RUBY, __FILE__, __LINE__ + 1
+            def method_missing(method, *args)
+              if #{!!attr.delegate}
+                value = method.to_s.gsub(/\\?\\Z/, '')
+                super unless #{attr.values}.include?(value)
+                raise ArgumentError if args.any?
+                value == #{attr.name}
+              else
+                super
+              end
+            end
+          RUBY
+
           include mod
         end
 

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -66,4 +66,32 @@ describe Enumerize::Integrations::Basic do
       klass.enumerize(:foo, :in => [:a, :b], :default => :c)
     }.must_raise ArgumentError
   end
+
+  describe 'delegated boolean methods' do
+    it 'raise exception if boolean method is not delegated' do
+      klass.enumerize(:foo, :in => [:a, :b])
+      proc {
+        object.a?
+      }.must_raise NoMethodError
+    end
+
+    it 'raise exception if boolean method is not included in values' do
+      klass.enumerize(:foo, :in => [:a, :b], :delegate => true)
+      proc {
+        object.c?
+      }.must_raise NoMethodError
+    end
+
+    it 'returns true if value equals method name' do
+      klass.enumerize(:foo, :in => [:a, :b], :delegate => true)
+      object.foo = :a
+      object.a?.must_equal true
+    end
+
+    it 'returns false if value do not equal method name' do
+      klass.enumerize(:foo, :in => [:a, :b], :delegate => true)
+      object.foo = :a
+      object.b?.must_equal false
+    end
+  end
 end


### PR DESCRIPTION
Can't get rid of warning about redefining `method_missing` so made a pull request

```
/home/dreamfall/ruby/enumerize/lib/enumerize/integrations/basic.rb:33: warning: method redefined; discarding old method_missing
/home/dreamfall/ruby/enumerize/lib/enumerize/integrations/basic.rb:33: warning: previous definition of method_missing was here
```
