### PR TITLE
I18n regression: Multiple calls to value #text return different resutls

### DIFF
--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -26,6 +26,7 @@ describe Enumerize::Base do
       object.foo = :a
       object.foo.text.must_equal 'a text'
       object.foo_text.must_equal 'a text'
+      object.foo_text.must_equal 'a text'
     end
   end
 


### PR DESCRIPTION
Calling `#text` on the value returned multiple times returns different results. I've attached a simple failing test, still working out the best patch to fix it.

A simple fix could be to just not cache the results of the `#i18n_keys` method.
