### PR TITLE
Add failing test for inheriting enumerized attributes

### DIFF
--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -6,6 +6,9 @@ describe Enumerize::Base do
       include Enumerize
     end
   end
+  let(:subklass) do
+    Class.new(klass)
+  end
 
   let(:object) { klass.new }
 
@@ -90,5 +93,10 @@ describe Enumerize::Base do
     method = klass.method(:name)
     klass.enumerize(:name, :in => %w[a b], :default => 'a')
     klass.method(:name).must_equal method
+  end
+
+  it "inherits enumerized attributes from a parent class" do
+    klass.enumerize(:foo, :in => %w[a b])
+    subklass.enumerized_attributes[:foo].must_be_instance_of Enumerize::Attribute
   end
 end


### PR DESCRIPTION
Enumerized attributes don't get inherited by subclasses.

``` ruby
class Foo < ActiveRecord::Base
  enumerized :baz, :in => %w[a b]
end

class Bar < Foo

end
```

I think it's because the class instance variable `@enumerized_attributes` isn't inherited by the subclass, so it's `nil`.
