### PR TITLE
Cast empty string values to nil for validations

### DIFF
--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -70,7 +70,7 @@ module Enumerize
           end
 
           def #{attr.name}=(new_value)
-            _enumerized_values_for_validation[:#{attr.name}] = new_value.nil? ? nil : new_value.to_s
+            _enumerized_values_for_validation[:#{attr.name}] = new_value.nil? || new_value.empty? ? nil : new_value.to_s
 
             allowed_value_or_nil = self.class.enumerized_attributes[:#{attr.name}].find_value(new_value)
             allowed_value_or_nil = allowed_value_or_nil.to_s unless allowed_value_or_nil.nil?

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -136,4 +136,10 @@ describe Enumerize::Base do
     object.foo = nil
     object.read_attribute_for_validation(:foo).must_equal nil
   end
+
+  it 'casts empty string to nil for validation' do
+    klass.enumerize(:foo, :in => [:a, :b])
+    object.foo = ''
+    object.read_attribute_for_validation(:foo).must_equal nil
+  end
 end


### PR DESCRIPTION
Here you go.  This casts empty string values to `nil` for validation purposes so they pass through the inclusion validator.  

I realize that we discussed our options and settled on this, but part of me is still wondering if we should have went the `:allow_blank => true` route.  It accomplishes the same thing with cleaner code and without changing the value that other validations will see.  Thoughts on this?

Jim
