### PR TITLE
redefine respond_to_missing for boolean methods

### DIFF
--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -18,7 +18,7 @@ module Enumerize
     end
 
     def method_missing(method, *args, &block)
-      if method[-1] == '?' && @attr.values.include?(method[0..-2])
+      if boolean_method?(method)
         define_query_methods
         send(method, *args, &block)
       else
@@ -26,13 +26,8 @@ module Enumerize
       end
     end
 
-    def respond_to?(method, include_private=false)
-      if super
-        true
-      elsif method[-1] == '?' && @attr.values.include?(method[0..-2])
-        define_query_methods
-        super
-      end
+    def respond_to_missing?(method, include_private=false)
+      boolean_method?(method)
     end
 
     private
@@ -64,6 +59,10 @@ module Enumerize
 
     def i18n_suffix
       "#{@attr.i18n_suffix}." if @attr.i18n_suffix
+    end
+
+    def boolean_method?(method)
+      method[-1] == '?' && @attr.values.include?(method[0..-2])
     end
   end
 end

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -42,6 +42,10 @@ describe Enumerize::Value do
       value.must_respond_to :other_value?
     end
 
+    it 'returns a method object' do
+      value.method(:test_value?).must_be_instance_of Method
+    end
+
     it "doesn't respond to a method for not existing value" do
       value.wont_respond_to :some_method?
     end


### PR DESCRIPTION
since we support only ruby > 1.9 I think it make sense to define `respond_to_missing` method when we are overriding `method_missing`. More info is here http://robots.thoughtbot.com/post/28335346416/always-define-respond-to-missing-when-overriding
