### PR TITLE
Changed the way attribute method is called in the generated code

### DIFF
--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -21,7 +21,7 @@ module Enumerize
 
         _enumerize_module.module_eval <<-RUBY, __FILE__, __LINE__ + 1
           def #{attr.name}_text
-            #{attr.name} && #{attr.name}.text
+            self.#{attr.name} && self.#{attr.name}.text
           end
         RUBY
 


### PR DESCRIPTION
I had a model with a field called 'when'. Current implementation generates such a code `when && when.text`. As long as `when` is a Ruby keyword, the code is not valid. I've changed this to generate `self.when && self.when.text`.
