### PR TITLE
prefer extend over include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## dev ##
 
+The previous method of adding enumerize to a class was deprecated. Please use
+`extend Enumerize` instead of `include Enumerize`.
+
 ### enhancements
   * SimpleForm support for multiple attributes. (by [@nashby](https://github.com/nashby))
   * Formtastic support for multiple attributes. (by [@nashby](https://github.com/nashby))

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Basic:
 
 ```ruby
 class User
-  include Enumerize
+  extend Enumerize
 
   enumerize :sex, :in => [:male, :female]
 end
@@ -32,7 +32,7 @@ ActiveRecord:
 
 ```ruby
 class User < ActiveRecord::Base
-  include Enumerize
+  extend Enumerize
 
   enumerize :sex, :in => [:male, :female]
 
@@ -45,7 +45,7 @@ Mongoid:
 ```ruby
 class User
   include Mongoid::Document
-  include Enumerize
+  extend Enumerize
 
   field :role
   enumerize :role, :in => [:user, :admin], :default => :user
@@ -105,7 +105,7 @@ Predicate methods:
 
 ```ruby
 class User
-  include Enumerize
+  extend Enumerize
   enumerize :sex, in: %w(male female), predicates: true
 end
 
@@ -124,7 +124,7 @@ Using prefix:
 
 ```ruby
 class User
-  include Enumerize
+  extend Enumerize
   enumerize :sex, in: %w(male female), predicates: { prefix: true }
 end
 
@@ -138,7 +138,7 @@ To make some attributes shared across different classes it's possible to define 
 
 ```ruby
 module PersonEnumerations
-  include Enumerize
+  extend Enumerize
 
   enumerize :sex, :in => %w[male female]
 end
@@ -164,7 +164,7 @@ Array-like attributes with plain ruby objects:
 
 ```ruby
 class User
-  include Enumerize
+  extend Enumerize
   enumerize :interests, :in => [:music, :sports], :multiple => true
 end
 
@@ -176,7 +176,7 @@ user.interests << :sports
 and with ActiveRecord:
 
 ```ruby
-  include Enumerize
+  extend Enumerize
   serialize :interests, Array
   enumerize :interests, :in => [:music, :sports], :multiple => true
 ```

--- a/lib/enumerize.rb
+++ b/lib/enumerize.rb
@@ -12,6 +12,11 @@ module Enumerize
   autoload :ModuleAttributes, 'enumerize/module_attributes'
 
   def self.included(base)
+    ActiveSupport::Deprecation.warn '`include Enumerize` was deprecated. Please use `extend Enumerize`.', caller
+    extended(base)
+  end
+
+  def self.extended(base)
     base.send :include, Enumerize::Base
     base.extend Enumerize::Predicates
 

--- a/lib/enumerize/module_attributes.rb
+++ b/lib/enumerize/module_attributes.rb
@@ -1,7 +1,7 @@
 module Enumerize
   module ModuleAttributes
     def included(base)
-      base.send :include, Enumerize
+      base.extend Enumerize
       base.send :include, _enumerize_module
       base.extend _enumerize_module._class_methods
       enumerized_attributes.add_dependant base.enumerized_attributes

--- a/lib/enumerize/predicates.rb
+++ b/lib/enumerize/predicates.rb
@@ -4,7 +4,7 @@ module Enumerize
   # Basic usage:
   #
   #     class User
-  #       include Enumerize
+  #       extend Enumerize
   #       enumerize :sex, in: %w(male female), predicates: true
   #     end
   #
@@ -21,7 +21,7 @@ module Enumerize
   # Using prefix:
   #
   #     class User
-  #       include Enumerize
+  #       extend Enumerize
   #       enumerize :sex, in: %w(male female), predicates: { prefix: true }
   #     end
   #

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -18,7 +18,7 @@ ActiveRecord::Base.connection.instance_eval do
 end
 
 class User < ActiveRecord::Base
-  include Enumerize
+  extend Enumerize
 
   enumerize :sex, :in => [:male, :female]
 

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Enumerize::Base do
   let(:klass) do
     Class.new do
-      include Enumerize
+      extend Enumerize
     end
   end
 
@@ -154,7 +154,7 @@ describe Enumerize::Base do
 
     klass = Class.new do
       include accessors
-      include Enumerize
+      extend Enumerize
 
       enumerize :foo, :in => %w[test]
     end

--- a/test/formtastic_test.rb
+++ b/test/formtastic_test.rb
@@ -28,7 +28,7 @@ class FormtasticSpec < MiniTest::Spec
     extend ActiveModel::Naming
     include ActiveModel::Conversion
 
-    include Enumerize
+    extend Enumerize
 
     enumerize :sex, :in => [:male, :female]
 
@@ -41,7 +41,7 @@ class FormtasticSpec < MiniTest::Spec
     extend ActiveModel::Naming
     include ActiveModel::Conversion
 
-    include Enumerize
+    extend Enumerize
 
     enumerize :categories, :in => [:music, :games], :multiple => true
 

--- a/test/module_attributes_test.rb
+++ b/test/module_attributes_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ModuleAttributesSpec < MiniTest::Spec
   it 'inherits attribute from the module' do
     mod = Module.new do
-      include Enumerize
+      extend Enumerize
       enumerize :sex, :in => %w[male female], :default => 'male'
     end
 
@@ -16,7 +16,7 @@ class ModuleAttributesSpec < MiniTest::Spec
 
   it 'uses new attributes from the module' do
     mod = Module.new do
-      include Enumerize
+      extend Enumerize
     end
 
     klass = Class.new

--- a/test/mongoid_test.rb
+++ b/test/mongoid_test.rb
@@ -13,7 +13,7 @@ end
 describe Enumerize do
   class MongoidUser
     include Mongoid::Document
-    include Enumerize
+    extend Enumerize
 
     field :sex
     field :role

--- a/test/multiple_test.rb
+++ b/test/multiple_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Enumerize::Base do
   let(:klass) do
     Class.new do
-      include Enumerize
+      extend Enumerize
     end
   end
 

--- a/test/predicates_test.rb
+++ b/test/predicates_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Enumerize::Predicates do
   let(:klass) do
     Class.new do
-      include Enumerize
+      extend Enumerize
     end
   end
 

--- a/test/set_test.rb
+++ b/test/set_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Enumerize::Set do
   let(:klass) do
     Class.new do
-      include Enumerize
+      extend Enumerize
       enumerize :foo, :in => %w(a b c), :multiple => true
     end
   end

--- a/test/simple_form_test.rb
+++ b/test/simple_form_test.rb
@@ -18,7 +18,7 @@ class SimpleFormSpec < MiniTest::Spec
     extend ActiveModel::Naming
     include ActiveModel::Conversion
 
-    include Enumerize
+    extend Enumerize
 
     enumerize :sex, :in => [:male, :female]
 
@@ -31,7 +31,7 @@ class SimpleFormSpec < MiniTest::Spec
     extend ActiveModel::Naming
     include ActiveModel::Conversion
 
-    include Enumerize
+    extend Enumerize
 
     enumerize :categories, :in => [:music, :games], :multiple => true
 


### PR DESCRIPTION
The previous method of adding enumerize to a class was deprecated. So
intead of:

```
include Enumerize
```

please use:

```
extend Enumerize
```

This prevents adding extra constants from Enumerize module (e.g.
Enumerize::ActiveRecord, Enumerize::Set) to the extended class. The
corresponding top-level constants can be accessed without using
top-level qualifier `::` now.
