### PR TITLE
Fix to use `write_attribute`

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -53,6 +53,8 @@ module Enumerize
 
           if defined?(super)
             super allowed_value_or_nil
+          elsif respond_to?(:write_attribute, true)
+            write_attribute '#{name}', allowed_value_or_nil
           else
             @#{name} = allowed_value_or_nil
           end
@@ -92,6 +94,8 @@ module Enumerize
 
           if defined?(super)
             super string_values
+          elsif respond_to?(:write_attribute, true)
+            write_attribute '#{name}', string_values
           else
             @#{name} = string_values
           end


### PR DESCRIPTION
In rails 4.0.0.beta1, ActiveRecord uses `@attributes` to keep its attributes (instead of instance variable named as attribute name).
Even if instance variable is assigned, attributes is not updated against my expectation.

So I use `write_attribute` to update model's attributes.
