### PR TITLE
Consider SEO query paramters

### DIFF
--- a/lib/enumerize/predicates.rb
+++ b/lib/enumerize/predicates.rb
@@ -65,7 +65,7 @@ module Enumerize
       end
 
       def build(klass)
-        klass.delegate(*names, to: @attr.name, prefix: @options[:prefix], allow_nil: true)
+        klass.delegate(*names.map{|n|n.to_s.gsub('-', '_')}, to: @attr.name, prefix: @options[:prefix], allow_nil: true)
       end
     end
   end

--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -34,9 +34,10 @@ module Enumerize
 
     def define_query_methods
       @attr.values.each do |value|
-        unless singleton_methods.include?(:"#{value}?")
+        method = value.gsub('-', '_')
+        unless singleton_methods.include?(:"#{method}?")
           singleton_class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def #{value}?
+            def #{method}?
               #{value == self}
             end
           RUBY
@@ -62,7 +63,7 @@ module Enumerize
     end
 
     def boolean_method?(method)
-      method[-1] == '?' && @attr.values.include?(method[0..-2])
+      method[-1] == '?' && @attr.values.map{|v|v.gsub('-', '_')}.include?(method[0..-2])
     end
   end
 end

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -50,4 +50,17 @@ describe Enumerize::Value do
       value.wont_respond_to :some_method?
     end
   end
+
+  describe 'boolean methods comparison with value with dash' do
+    let(:value) { Enumerize::Value.new(attr, 'test-value') }
+
+    before do
+      attr.values = [value]
+    end
+
+    it 'define boolean method' do
+      value.must_respond_to :test_value?
+      value.method(:test_value?).must_be_instance_of Method
+    end
+  end
 end


### PR DESCRIPTION
When you search google, "xx_yy" in the URL is considered as one word while "xx-yy" is considered as the combination of two words.
