### PR TITLE
Fix for active_admin

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -18,7 +18,11 @@ module Enumerize
         raise ArgumentError, 'invalid default value' unless @default_value
       end
     end
-
+    
+    def empty?
+      false
+    end
+    
     def find_value(value)
       @value_hash[value.to_s] unless value.nil?
     end


### PR DESCRIPTION
undefined method `empty?' for #Enumerize::Attribute:0x00000008348110

with field type :enum
