### PR TITLE
Add _value method to enumerized class

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -82,6 +82,10 @@ module Enumerize
         def #{name}_text
           self.#{name} && self.#{name}.text
         end
+
+        def #{name}_value
+          self.#{name} && self.#{name}.value
+        end
       RUBY
     end
   end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -174,9 +174,13 @@ describe Enumerize::Base do
     object.foo = :a
     object.instance_variable_get(:@foo).must_equal 1
     object.foo.must_equal 'a'
+    object.foo.value.must_equal 1
+    object.foo_value.must_equal 1
 
     object.foo = :b
     object.instance_variable_get(:@foo).must_equal 2
     object.foo.must_equal 'b'
+    object.foo.value.must_equal 2
+    object.foo_value.must_equal 2
   end
 end

--- a/test/multiple_test.rb
+++ b/test/multiple_test.rb
@@ -28,4 +28,9 @@ describe Enumerize::Base do
     klass.enumerize :foos, in: %w(a b c), multiple: true
     object.wont_respond_to :foos_text
   end
+
+  it "doesn't define _value method" do
+    klass.enumerize :foos, in: %w(a b c), multiple: true
+    object.wont_respond_to :foos_value
+  end
 end


### PR DESCRIPTION
I want to use it in using a hash as `:in` option.
I'm not good at English, so i wrote a example code :sweat_smile:

``` ruby
class User
  extend Enumerize

  enumerize :role, in: {:user => 1, :admin => 2}
end

user = User.new.tap{ |u| u.role = "user" }
user.role_value
# => 1
```
