### PR TITLE
Add document about using `extend ActiveModel::Naming`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ en:
       female: "Female"
 ```
 
+If you want to separate I18n namespace by model name except for `ActiveRecord::Base` inherited class, your class should extend `ActiveModel::Naming`.
+
+```ruby
+class User
+  extend Enumerize
+  extend ActiveModel::Naming
+
+  (snip)
+end
+```
+
 get attribute value:
 
 ```ruby


### PR DESCRIPTION
Hi again, I found a small problem.
I want to separate I18n namespace with model name using inherited Object class.
It is possible by doing it, but it is undocumented.

``` ruby
class User
  extend Enumerize
  extend ActiveModel::Naming

  (snip)
end
```

Then I added it to README.md.

Please refactor my English as you like :D
