### PR TITLE
Moving boolean methods section

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,6 @@ use it with forms (it supports `:only` and `:except` options):
 <% end %>
 ```
 
-Boolean methods:
-
-```ruby
-user.sex = :male
-user.sex.male? #=> true
-user.sex.female? #=> false
-```
-
 Predicate methods:
 
 ```ruby
@@ -119,6 +111,14 @@ user.sex = 'male'
 
 user.male?   # => true
 user.female? # => false
+```
+
+Boolean methods:
+
+```ruby
+user.sex = :male
+user.sex.male? #=> true
+user.sex.female? #=> false
 ```
 
 Using prefix:


### PR DESCRIPTION
Calling enumerized values as predicate methods is dependent on the step described in the "Predicate methods" section. As such, this section seems to make better sense coming after that section than before it.
