### PR TITLE
Give priority to model specific translation definition

### DIFF
--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -32,8 +32,8 @@ module Enumerize
     def i18n_keys
       @i18n_keys ||= begin
         i18n_keys = []
-        i18n_keys << i18n_scope
         i18n_keys << i18n_scope(i18n_suffix)
+        i18n_keys << i18n_scope
         i18n_keys << self.humanize # humanize value if there are no translations
       end
     end

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -12,6 +12,34 @@ describe Enumerize::Value do
     value.must_be :==, 'test_value'
   end
 
+  describe 'translation' do
+    let(:attr)  { Struct.new(:values, :name, :i18n_suffix).new([], "attribute_name", "model_name") }
+
+    it 'uses common translation' do
+      store_translations(:en, :enumerize => {:attribute_name => {:test_value => "Common translation"}}) do
+        value.text.must_be :==, "Common translation"
+      end
+    end
+
+    it 'uses model specific translation' do
+      store_translations(:en, :enumerize => {:model_name => {:attribute_name => {:test_value => "Model Specific translation"}}}) do
+        value.text.must_be :==, "Model Specific translation"
+      end
+    end
+
+    it 'uses model specific translation rather than common translation' do
+      store_translations(:en, :enumerize => {:attribute_name => {:test_value => "Common translation"}, :model_name => {:attribute_name => {:test_value => "Model Specific translation"}}}) do
+        value.text.must_be :==, "Model Specific translation"
+      end
+    end
+
+    it 'uses simply humanized value when translation is undefined' do
+      store_translations(:en, :enumerize => {}) do
+        value.text.must_be :==, "Test value"
+      end
+    end
+  end
+
   describe 'boolean methods comparison' do
     before do
       attr.values = [value, Enumerize::Value.new(attr, 'other_value')]


### PR DESCRIPTION
If translations are defined below, I expect that `User.status.values[0].text` is "Activation required" and `OtherModel.status.values[0].text` is "Pending".

``` yml
en:
  enumerize:
    status:
      pending: "Pending"
    user:
      status:
        pending: "Activation required"
```

But now, they both return "Pending".

When more than one translations exist for an attribute, I want to get more 'deeper' one (this behavior is similar to ActiveModel::Translation#human_attribute_name).
