### PR TITLE
Shortcut methods to retrieve value and text of enum

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -17,6 +17,11 @@ module Enumerize
         @default_value = find_default_value(options[:default])
         raise ArgumentError, 'invalid default value' unless @default_value
       end
+
+      # Define methods to get each value
+      @values.each do |name, value|
+        define_method(name) { value.value }
+      end
     end
 
     def find_default_value(value)

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -20,7 +20,8 @@ module Enumerize
 
       # Define methods to get each value
       @values.each do |name, value|
-        define_method(name) { value.value }
+        metaclass = class << self; self; end
+        metaclass.send(:define_method, name) { value.value }
       end
     end
 

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -21,8 +21,7 @@ module Enumerize
       # Define methods to get each value
       @values.each do |v|
         metaclass = class << self; self; end
-        metaclass.send(:define_method, v.to_s) { v.value }
-        metaclass.send(:define_method, v.to_s + '_text' ) { v.text }
+        metaclass.send(:define_method, v.to_s) { v }
       end
     end
 

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -19,9 +19,9 @@ module Enumerize
       end
 
       # Define methods to get each value
-      @values.each do |name, value|
+      @values.each do |v|
         metaclass = class << self; self; end
-        metaclass.send(:define_method, name) { value.value }
+        metaclass.send(:define_method, v.to_s) { v.value }
       end
     end
 

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -31,6 +31,10 @@ module Enumerize
       @value_hash[value.to_s] unless value.nil?
     end
 
+    def value_for(value)
+      find_value(value).value
+    end
+
     def i18n_suffix
       @klass.model_name.i18n_key if @klass.respond_to?(:model_name)
     end

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -22,6 +22,7 @@ module Enumerize
       @values.each do |v|
         metaclass = class << self; self; end
         metaclass.send(:define_method, v.to_s) { v.value }
+        metaclass.send(:define_method, v.to_s + '_text' ) { v.text }
       end
     end
 
@@ -35,10 +36,6 @@ module Enumerize
 
     def find_value(value)
       @value_hash[value.to_s] unless value.nil?
-    end
-
-    def value_for(value)
-      find_value(value).value
     end
 
     def i18n_suffix

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -67,4 +67,12 @@ describe Enumerize::Attribute do
       attr.find_value(2).must_equal 'b'
     end
   end
+
+  it 'sets up shortcut methods for each value' do
+    build_attr nil, :foo, :in => {:a => 1, :b => 2}
+    attr.a.value.must_equal 1
+    attr.b.value.must_equal 2
+    attr.a.text.must_equal 'A'
+    attr.b.text.must_equal 'B'
+  end
 end


### PR DESCRIPTION
Define shortcut methods to retrieve the value and text of an enum from the class (as opposed to an instance)

With the following class definition:
``` ruby 
class Client < ActiveRecord::Base
  extend Enumerize
  enumerize :status, in: {inactive: 0, active: 1}
end
```

You can retrieve the values of the enum by calling:
``` ruby
Client.status.find_value(:active).value #=> 1
```
but this is clunky and overly verbose, especially when trying to put together a sql query, etc.  

This adds two new methods to the attribute for each value:
``` ruby
Client.status.active #=> 1
Client.status.active_text #=> 'Active'
```

These are inline with the spirit of the methods available to instances and allow for more concise retrieval of enum values.

Let me know if you have any questions or there is anything you would like me to change.
