### PR TITLE
Fix use of rspec with spork eliminating Gemfile sequence dependence

### DIFF
--- a/lib/enumerize.rb
+++ b/lib/enumerize.rb
@@ -2,15 +2,15 @@ require 'active_support/concern'
 require 'enumerize/version'
 
 module Enumerize
-  autoload :Attribute,    'enumerize/attribute'
-  autoload :AttributeMap, 'enumerize/attribute_map'
-  autoload :Value,        'enumerize/value'
-  autoload :Set,          'enumerize/set'
-  autoload :Base,         'enumerize/base'
-  autoload :Module,       'enumerize/module'
-  autoload :ActiveRecord, 'enumerize/activerecord'
-  autoload :Predicates,   'enumerize/predicates'
-  autoload :Predicatable, 'enumerize/predicatable'
+  autoload :Attribute,        'enumerize/attribute'
+  autoload :AttributeMap,     'enumerize/attribute_map'
+  autoload :Value,            'enumerize/value'
+  autoload :Set,              'enumerize/set'
+  autoload :Base,             'enumerize/base'
+  autoload :Module,           'enumerize/module'
+  autoload :ActiveRecord,     'enumerize/activerecord'
+  autoload :Predicates,       'enumerize/predicates'
+  autoload :Predicatable,     'enumerize/predicatable'
   autoload :ModuleAttributes, 'enumerize/module_attributes'
 
   def self.included(base)
@@ -49,7 +49,5 @@ module Enumerize
   rescue LoadError
   end
 
-  if defined?(::RSpec)
-    require 'enumerize/integrations/rspec'
-  end
+  require 'enumerize/integrations/rspec'
 end


### PR DESCRIPTION
I'm trying to use enumerize matcher in rspec + spork and I'm receiving the following error message:

<pre>
Failure/Error: should enumerize(:uf)
     NoMethodError:
       undefined method `enumerize' for #<RSpec::Core::ExampleGroup::Nested_1:0x007ff9f98b5510>
</pre>


If I disable spork the spec pass. 

I think the problem is that rspec cannot find the matcher.

If I put the line above at spec_helper everything pass again:

<pre>
require "enumerize/integrations/rspec"
</pre>


This is my entire spec_helper:
https://gist.github.com/cesarjr/7571792#file-spec_helper-rb

I was reading the Enumerize code and I found theses lines:

https://github.com/brainspec/enumerize/blob/master/lib/enumerize.rb

<pre>
if defined?(::RSpec)
  require 'enumerize/integrations/rspec'
end
</pre>


So... I checked my Gemfile and I notice that Enumerize was being declared before rspec.Like this:

<pre>
gem "enumerize", "0.7.0"
gem "rspec-rails", "2.14.0"
</pre>


I inverted and everything passed.

My question is: this dependency of Gemfile declaration sequence is expected?

Wouldn't be better if <tt>require 'enumerize/integrations/rspec'</tt> always happen?
