### PR TITLE
Serialize Enumerize::Value as string

### DIFF
--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -19,6 +19,10 @@ module Enumerize
       I18n.t(i18n_keys[0], :default => i18n_keys[1..-1])
     end
 
+    def encode_with(coder)
+      coder.represent_object(self.class.superclass, @value)
+    end
+
     private
 
     def define_query_method(value)

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -286,4 +286,12 @@ describe Enumerize::ActiveRecord do
 
     assert_equal expected, document.updated_at
   end
+
+  it 'changes from dirty should be serialized as scalar values' do
+    user = User.create(:status => :active)
+    user.status = :blocked
+
+    expected = ActiveSupport::HashWithIndifferentAccess.new(status: [1, 2]).to_yaml
+    assert_equal expected, user.changes.to_yaml
+  end
 end

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -78,4 +78,10 @@ describe Enumerize::Value do
       value.wont_respond_to :some_method?
     end
   end
+
+  describe 'serialization' do
+    it 'should be serialized to yaml as string value' do
+      assert_equal YAML.dump('test_value'), YAML.dump(value)
+    end
+  end
 end


### PR DESCRIPTION
Currently enumerized field is a `Enumerize::Value` and it is serialized as this object, but it should be `String`. There is no any reason to serialize it as custom object ans save it to database.

`ActiveRecord` uses [YAML.load](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/coders/yaml_column.rb#L13) to serialize object. So the test shows that dumping works as expected.
