### PR TITLE
Require rspec/matchers before require enumerate/integrations/rspec.

### DIFF
--- a/lib/enumerize.rb
+++ b/lib/enumerize.rb
@@ -50,7 +50,10 @@ module Enumerize
   rescue LoadError
   end
 
-  if defined?(::RSpec)
+  begin
+    require 'rspec/matchers'
+  rescue LoadError
+  else
     require 'enumerize/integrations/rspec'
   end
 end


### PR DESCRIPTION
Using Rails 4.0.3, Ruby 2.1 with `rails/spring`.

When `if defined?(::RSpec)` is used, and specs are ran with either `spring rake` or `spring rspec` it fails to load the enumerize matcher properly.

```
NoMethodError:
   undefined method `enumerize' for #<RSpec::Core::ExampleGroup::Nested_2::Nested_1:0x000001014521b0>
```

As described in https://github.com/rails/spring/issues/209, the solution is to `require rspec/matchers` before the enumerize matcher.
