### PR TITLE
Equality Operator - Compare to Symbols and Integers

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -21,8 +21,7 @@ module Enumerize
       # Define methods to get each value
       @values.each do |v|
         metaclass = class << self; self; end
-        metaclass.send(:define_method, v.to_s) { v.value }
-        metaclass.send(:define_method, v.to_s + '_text' ) { v.text }
+        metaclass.send(:define_method, v.to_s) { v }
       end
     end
 

--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -19,6 +19,13 @@ module Enumerize
       I18n.t(i18n_keys[0], :default => i18n_keys[1..-1])
     end
 
+    def ==(other)
+      return super(other) if other.is_a? String
+      return super(other.to_s) if other.is_a? Symbol
+      return value == other if other.is_a?(Integer) && value.is_a?(Integer)
+      super other
+    end
+
     private
 
     def define_query_method(value)

--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -18,10 +18,7 @@ module Enumerize
     end
 
     def ==(other)
-      return super(other) if other.is_a? String
-      return super(other.to_s) if other.is_a? Symbol
-      return value == other if other.is_a?(Integer) && value.is_a?(Integer)
-      super other
+      super(other.to_s) || value == other
     end
 
     def encode_with(coder)

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -2,14 +2,27 @@ require 'test_helper'
 
 describe Enumerize::Value do
   let(:attr)  { Struct.new(:values).new([]) }
-  let(:value) { Enumerize::Value.new(attr, 'test_value') }
+  let(:value) { Enumerize::Value.new(attr, 'test_value', 1) }
 
   it 'is a string' do
     value.must_be_kind_of String
   end
 
-  it 'is compared to string' do
-    value.must_be :==, 'test_value'
+  describe 'equality' do
+    it 'is compared to string' do
+      value.must_be :==, 'test_value'
+      value.wont_be :==, 'not_value'
+    end
+
+    it 'is compared to symbol' do
+      value.must_be :==, :test_value
+      value.wont_be :==, :not_value
+    end
+
+    it 'is compared to integer' do
+      value.must_be :==, 1
+      value.wont_be :==, 2
+    end
   end
 
   describe 'translation' do

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -119,6 +119,8 @@ describe Enumerize::Value do
   end
 
   describe 'serialization' do
+    let(:value) { Enumerize::Value.new(attr, 'test_value') }
+
     it 'should be serialized to yaml as string value' do
       assert_equal YAML.dump('test_value'), YAML.dump(value)
     end


### PR DESCRIPTION
The `==` operator should behave sanely when comparing to symbols and integers.  

With the following class:
``` ruby
class Patient < ActiveRecord::Base
  extend Enumerize
  enumerize :status, in: { inactive: 0, active: 1 }, scope: true
end
```

I can currently run:
``` ruby
Patient.first.status == 'inactive'
```

But will never work and always return false:
```ruby
Patient.first.status == :inactive
Patient.first.status == 0
```

I can assign a enumerized field a symbol (`Patient.first.status = :inactive`) or an integer (`Patient.first.status = 0`), so I should be able to compare against them as well.

This patch allows comparing to symbols and integers.  