### PR TITLE
Check attribute existence.

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -72,7 +72,7 @@ module Enumerize
         def #{name}
           if defined?(super)
             self.class.enumerized_attributes[:#{name}].find_value(super)
-          elsif respond_to?(:read_attribute)
+          elsif respond_to?(:read_attribute) && (!respond_to?(:has_attribute?, true) || has_attribute?(:#{name}))
             self.class.enumerized_attributes[:#{name}].find_value(read_attribute(:#{name}))
           else
             if defined?(@#{name})
@@ -91,7 +91,7 @@ module Enumerize
 
           if defined?(super)
             super allowed_value_or_nil
-          elsif respond_to?(:write_attribute, true)
+          elsif respond_to?(:write_attribute, true) && (!respond_to?(:has_attribute?, true) || has_attribute?(:#{name}))
             write_attribute '#{name}', allowed_value_or_nil
           else
             @#{name} = allowed_value_or_nil
@@ -116,7 +116,7 @@ module Enumerize
           unless defined?(@_#{name}_enumerized_set)
             if defined?(super)
               self.#{name} = super
-            elsif respond_to?(:read_attribute)
+            elsif respond_to?(:read_attribute) && (!respond_to?(:has_attribute?, true) || has_attribute?(:#{name}))
               self.#{name} = read_attribute(:#{name})
             else
               if defined?(@#{name})
@@ -138,7 +138,7 @@ module Enumerize
 
           if defined?(super)
             super string_values
-          elsif respond_to?(:write_attribute, true)
+          elsif respond_to?(:write_attribute, true) && (!respond_to?(:has_attribute?, true) || has_attribute?(:#{name}))
             write_attribute '#{name}', string_values
           else
             @#{name} = string_values

--- a/test/mongoid_test.rb
+++ b/test/mongoid_test.rb
@@ -17,6 +17,7 @@ describe Enumerize do
 
     field :sex
     field :role
+    field :mult
     enumerize :sex, :in => %w[male female]
     enumerize :role, :in => %w[admin user], :default => 'user'
     enumerize :mult, :in => %w[one two three four], :multiple => true


### PR DESCRIPTION
Please take a look of the following code.

``` rb
class User < ActiveRecord::Base
  # This model has only "role_with_column" column.
  enumerize :role_with_column, in: [:normal, :admin]
  enumerize :role_without_column, in: [:normal, :admin]  
end
```

This code show a warning below because role_without_column column does not exist.
**DEPRECATION WARNING: You're trying to create an attribute `offer_type_for_client'. Writing arbitrary attributes on a model is deprecated. Please just use `attr_writer` etc.**

A workaround is below.

``` rb
class User < ActiveRecord::Base
  # This model has only "role_with_column" column.
  enumerize :role_with_column, in: [:normal, :admin]
  attr_accessor :role_without_column
  enumerize :role_without_column, in: [:normal, :admin]  
end
```

However, I think this workaround is kind of redundant since `attr_accessor` is not necessary if the class is not an ActiveRecord::Base. Could you consider to merge this change?
