### PR TITLE
Key of hash _enumerized_values_for_validation handled unified as Symbol

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -45,7 +45,7 @@ module Enumerize
       # https://github.com/brainspec/enumerize/issues/74
       def write_attribute(attr_name, value)
         if self.class.enumerized_attributes[attr_name]
-          _enumerized_values_for_validation[attr_name.to_sym] = value
+          _enumerized_values_for_validation[attr_name.to_s] = value
         end
 
         super


### PR DESCRIPTION
I got a strange active record validation error on save of an object with 2 enumerated fields (`:left_type` end `:right_type`):

The object just before save:

```
#<ObjectLink id: nil, left_id: 10, left_type: "Document", right_id: 13, right_type: "Document", note: nil, created_at: nil, updated_at: nil>
```

The validation errors:

```
["Left type can't be blank", "Right type can't be blank"]
```

This bug is caused by the fact, that the keys for the `_enumerized_values_for_validation` are not handled unified. It handled basically as Symbol but in `lib/enumerize/activerecord.rb`in method `write_attribute` as String. So I got in `_enumerized_values_for_validation` the following:

```
{:left_type=>nil,
 "left_type"=>"Document",
 :right_type=>nil,
 "right_type"=>"Document"}
```

This pull request fixes this problem.
