### PR TITLE
Attribute#options returns correct values for interger columns

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -67,7 +67,7 @@ module Enumerize
         end
       end
 
-      values.map { |v| [v.text, v.to_s] }
+      values.map { |v| [v.text, v.value] }
     end
 
     def define_methods!(mod)

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -62,6 +62,13 @@ describe Enumerize::Attribute do
       end
     end
 
+    it 'returns requested options for select when column is integer' do
+      store_translations(:en, :enumerize => {:foo => {:a => 'a text', :b => 'b text'}}) do
+        build_attr nil, :foo, :in => { a: 1, b: 2 }
+        attr.options.must_equal [['a text', 1], ['b text', 2]]
+      end
+    end
+
     it 'does not work with both :only and :except' do
       store_translations(:en, :enumerize => {:foo => {:a => 'a text', :b => 'b text'}}) do
         build_attr nil, :foo, :in => %w[a b]


### PR DESCRIPTION
Attribute#options used to return string value for integer columns.
