### PR TITLE
Require `active_support/core_ext/module/delegation`

### DIFF
--- a/lib/enumerize/predicates.rb
+++ b/lib/enumerize/predicates.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/delegation'
+
 module Enumerize
   # Predicate methods.
   #

--- a/lib/enumerize/set.rb
+++ b/lib/enumerize/set.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/delegation'
+
 module Enumerize
   class Set
     include Enumerable


### PR DESCRIPTION
To work without Rails, `active_support/core_ext/module/delegation` needs
to be required to use the `#delegate` method.
