### PR TITLE
Be more explicit about definition of enumerize with :scope and :multiple options

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ User.having_status(:blocked).with_sex(:male, :female)
 # SELECT "users".* FROM "users" WHERE "users"."status" IN (2) AND "users"."sex" IN ('male', 'female')
 ```
 
+:warning: It is not possible to define a scope when using the `:multiple` option. :warning:
+
 Array-like attributes with plain ruby objects:
 
 ```ruby

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -4,6 +4,7 @@ module Enumerize
 
     def initialize(klass, name, options={})
       raise ArgumentError, ':in option is required' unless options[:in]
+      raise ArgumentError, ':scope option does not work with option :multiple' if options[:multiple] && options[:scope]
 
       extend Multiple if options[:multiple]
 

--- a/test/multiple_test.rb
+++ b/test/multiple_test.rb
@@ -33,4 +33,10 @@ describe Enumerize::Base do
     klass.enumerize :foos, in: %w(a b c), multiple: true
     object.wont_respond_to :foos_value
   end
+
+  it "cannot define multiple with scope" do
+    assert_raises ArgumentError do
+      klass.enumerize :foos, in: %w(a b c), multiple: true, scope: true
+    end
+  end
 end


### PR DESCRIPTION
[Since enumerize does not support definition of scope when using the multiple option](https://github.com/brainspec/enumerize/issues/113), I propose that we raise a exception and show this info on the README.

What you think? :smile: 

