### PR TITLE
Use alias_method_chain instead of overriding Class#inherited

### DIFF
--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -8,9 +8,10 @@ module Enumerize
       end
 
       class << base
-        if self.respond_to? :inherited
+        if method_defined?(:inherited) && (not method_defined? :inherited_without_enumerized)
           alias_method :inherited_without_enumerized, :inherited
         end
+
         alias_method :inherited, :inherited_with_enumerized
       end
     end
@@ -37,8 +38,7 @@ module Enumerize
 
       def inherited_with_enumerized(subclass)
         enumerized_attributes.add_dependant subclass.enumerized_attributes
-
-        if respond_to?  :inherited_without_enumerized
+        if respond_to?(:inherited_without_enumerized, true)
           inherited_without_enumerized subclass
         end
       end

--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -6,6 +6,11 @@ module Enumerize
       if base.respond_to?(:validate)
         base.validate :_validate_enumerized_attributes
       end
+
+      class << base
+        alias_method :inherited_without_enumerized, :inherited
+        alias_method :inherited, :inherited_with_enumerized
+      end
     end
 
     module ClassMethods
@@ -28,9 +33,9 @@ module Enumerize
         @enumerized_attributes ||= AttributeMap.new
       end
 
-      def inherited(subclass)
+      def inherited_with_enumerized(subclass)
         enumerized_attributes.add_dependant subclass.enumerized_attributes
-        super
+        inherited_without_enumerized subclass
       end
 
       private

--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -8,7 +8,9 @@ module Enumerize
       end
 
       class << base
-        alias_method :inherited_without_enumerized, :inherited
+        if self.respond_to? :inherited
+          alias_method :inherited_without_enumerized, :inherited
+        end
         alias_method :inherited, :inherited_with_enumerized
       end
     end
@@ -35,7 +37,10 @@ module Enumerize
 
       def inherited_with_enumerized(subclass)
         enumerized_attributes.add_dependant subclass.enumerized_attributes
-        inherited_without_enumerized subclass
+
+        if respond_to?  :inherited_without_enumerized
+          inherited_without_enumerized subclass
+        end
       end
 
       private


### PR DESCRIPTION
Overridding `Class#inerited` hook makes trouble when other gems/modules doing so.

`Enumerize::ClassMethods#inherited` will be overwritten and doesn't
executed when other module tryed to hook the inherited method.

To avoid this problem, it would stop to rewrite the inherited hook
and use `alias_method_chain`.

please see following discussion.

- Use of the singleton class method 'inherited' Issue #165 amatsuda/kaminari
  https://github.com/amatsuda/kaminari/issues/165