### PR TITLE
Allow text_transform when configuring attributes

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -1,6 +1,6 @@
 module Enumerize
   class Attribute
-    attr_reader :name, :values, :default_value, :i18n_scope
+    attr_reader :name, :values, :default_value, :i18n_scope, :text_transform
 
     def initialize(klass, name, options={})
       raise ArgumentError, ':in option is required' unless options[:in]
@@ -25,6 +25,10 @@ module Enumerize
       if options[:default]
         @default_value = find_default_value(options[:default])
         raise ArgumentError, 'invalid default value' unless @default_value
+      end
+
+      if options[:text_transform]
+        @text_transform = options[:text_transform]
       end
     end
 

--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -36,7 +36,14 @@ module Enumerize
         i18n_keys = i18n_scopes
         i18n_keys << [:"enumerize.defaults.#{@attr.name}.#{self}"]
         i18n_keys << [:"enumerize.#{@attr.name}.#{self}"]
-        i18n_keys << self.underscore.humanize # humanize value if there are no translations
+
+        # if there are no translations
+        i18n_keys << if @attr.text_transform.nil?
+                       self.underscore.humanize
+                     else
+                       @attr.text_transform.call(self)
+                     end
+
         i18n_keys.flatten
       end
     end

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -13,7 +13,7 @@ describe Enumerize::Value do
   end
 
   describe 'translation' do
-    let(:attr)  { Struct.new(:values, :name, :i18n_scopes).new([], "attribute_name", []) }
+    let(:attr)  { Struct.new(:values, :name, :i18n_scopes, :text_transform).new([], "attribute_name", [], nil) }
 
     it 'uses common translation' do
       store_translations(:en, :enumerize => {:attribute_name => {:test_value => "Common translation"}}) do
@@ -40,6 +40,13 @@ describe Enumerize::Value do
 
       store_translations(:en, :enumerize => {:attribute_name => {:test_value => "Common translation"}, :model_name => {:attribute_name => {:test_value => "Model Specific translation"}}}) do
         value.text.must_be :==, "Model Specific translation"
+      end
+    end
+
+    it 'uses text_transform proc when translation is undefined' do
+      attr.text_transform = proc { |value| value.dasherize }
+      store_translations(:en, :enumerize => {}) do
+        value.text.must_be :==, "test-value"
       end
     end
 


### PR DESCRIPTION
For certain cases, I need to override the default conversion from value to text. I would prefer not to muck around in I18n since these aren't really translations.

Example:
```ruby
class Site
  extend Enumerize
  enumerize :url, in: %w[smbc-comics.com penny-arcade.com], text_transform: proc{|value| value} # force text == value
end
```