### PR TITLE
Use Mongoid's `:in` method for generated scopes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### enhancements
 
 ### bug fix
+ * Use Mongoid's `:in` method for generated scopes, fix chained scopes. (by [@nashby](https://github.com/nashby))
  * Use `after_initialize` callback to set default value in Mongoid documents. (by [@nashby](https://github.com/nashby))
 
 ## 0.10.1 (March 4, 2015) ##

--- a/lib/enumerize/scope/mongoid.rb
+++ b/lib/enumerize/scope/mongoid.rb
@@ -20,12 +20,7 @@ module Enumerize
 
         define_singleton_method scope_name do |*values|
           values = enumerized_attributes[name].find_values(*values).map(&:value)
-
-          if values.size == 1
-            where(name => values.first)
-          else
-            where(name.in => values)
-          end
+          self.in(name => values)
         end
 
         if options[:scope] == true

--- a/test/mongoid_test.rb
+++ b/test/mongoid_test.rb
@@ -19,9 +19,10 @@ describe Enumerize do
 
     field :sex
     field :role
-    enumerize :sex, :in => %w[male female], scope: true
-    enumerize :role, :in => %w[admin user], :default => 'user', scope: :having_role
-    enumerize :mult, :in => %w[one two three four], :multiple => true
+    enumerize :sex,    :in => %w[male female], scope: true
+    enumerize :status, :in => %w[notice warning error], scope: true
+    enumerize :role,   :in => %w[admin user], :default => 'user', scope: :having_role
+    enumerize :mult,   :in => %w[one two three four], :multiple => true
   end
 
   before { $VERBOSE = nil }
@@ -103,6 +104,17 @@ describe Enumerize do
 
     model.having_role(:admin).to_a.must_equal [user_1]
     model.having_role(:user).to_a.must_equal [user_2]
+  end
+
+  it 'chains scopes' do
+    model.delete_all
+
+    user_1 = model.create!(status: :notice)
+    user_2 = model.create!(status: :warning)
+    user_3 = model.create!(status: :error)
+
+    model.with_status(:notice, :warning).with_status(:notice, :error).to_a.must_equal [user_1]
+    model.with_status(:notice, :warning).union.with_status(:notice, :error).to_a.must_equal [user_1, user_2, user_3]
   end
 
   it 'ignores not enumerized values that passed to the scope method' do


### PR DESCRIPTION
Fix chained scopes. Closes #184.