### PR TITLE
Add ability to set default value for enumerized field with multiple type.

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -134,6 +134,14 @@ module Enumerize
   end
 
   module Multiple
+    def find_default_value(value)
+      if value.respond_to?(:call)
+        value
+      else
+        find_values(*value)
+      end
+    end
+
     def define_methods!(mod)
       mod.module_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{name}

--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -99,7 +99,9 @@ module Enumerize
           next
         end
 
-        if !attr_value && !_enumerized_values_for_validation.key?(attr.name.to_s)
+        value_for_validation = _enumerized_values_for_validation[attr.name.to_s]
+
+        if (!attr_value || attr_value.empty?) && (!value_for_validation || value_for_validation.empty?)
           value = attr.default_value
 
           if value.respond_to?(:call)

--- a/test/multiple_test.rb
+++ b/test/multiple_test.rb
@@ -24,6 +24,21 @@ describe Enumerize::Base do
     object.foos.must_equal %w(a c)
   end
 
+  it 'sets default value as single value' do
+    klass.enumerize :foos, in: %w(a b c), default: 'b', multiple: true
+    object.foos.must_equal %w(b)
+  end
+
+  it 'sets default value as array of one element' do
+    klass.enumerize :foos, in: %w(a b c), default: %w(b), multiple: true
+    object.foos.must_equal %w(b)
+  end
+
+  it 'sets default value as array of several elements' do
+    klass.enumerize :foos, in: %w(a b c), default: %w(b c), multiple: true
+    object.foos.must_equal %w(b c)
+  end
+
   it "doesn't define _text method" do
     klass.enumerize :foos, in: %w(a b c), multiple: true
     object.wont_respond_to :foos_text


### PR DESCRIPTION
closes #186 

We could just use `.blank?` [there](https://github.com/brainspec/enumerize/compare/issue-186?expand=1#diff-089b5c707e42d821bb06498c34d0b293R104) but since we're planning to remove activesupport deps we need this large `if`. @lest @dreamfall what do you think?