### PR TITLE
Add README example for overriding the reader method using super

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,18 @@ class User < ActiveRecord::Base
 end
 ```
 
+Also, the reader method can be overridden, referencing the enumerized attribute value using `super`:
+
+```ruby
+def sex
+  if current_user.admin?
+    "Super#{super}"
+  else
+    super
+  end
+end
+```
+
 ### SimpleForm
 
 If you are using SimpleForm gem you don't need to specify input type (`:select` by default) and collection:


### PR DESCRIPTION
Example is somewhat contrived. Feedback welcome.

See https://github.com/brainspec/enumerize/commit/71462d0a930ee3c052a19c6f430d6965c6cb58ea#commitcomment-10787496 for context.