### PR TITLE
fix options

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -72,7 +72,7 @@ module Enumerize
         end
       end
 
-      values.map { |v| [v.text, v.to_s] }
+      values.map { |v| [v.text, v.value] }
     end
 
     def respond_to_missing?(method, include_private=false)


### PR DESCRIPTION
In this case: 
```
class User < ActiveRecord::Base
  extend Enumerize
  enumerize :role, in: {:user => 1, :admin => 2}
end
```

User.role.options returns `[["User", 1], ["Admin", 2]]`
