### PR TITLE
Use Symbol#to_proc instead of block

### DIFF
--- a/lib/enumerize/set.rb
+++ b/lib/enumerize/set.rb
@@ -37,7 +37,7 @@ module Enumerize
     end
 
     def texts
-      @values.collect { |value| value.text }
+      @values.map(&:text)
     end
 
     delegate :join, to: :to_ary


### PR DESCRIPTION
Symbol#to_proc is more concise and is faster than the block version. See benchmark results here: https://github.com/JuanitoFatas/fast-ruby#block-vs-symbolto_proc-code

`map` is also preferred over `collect` by the Ruby Style Guide:
https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size