### PR TITLE
Add more qualifiers on the RSpec matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,15 +322,125 @@ Also you can use builtin RSpec matcher:
 class User
   extend Enumerize
 
-  enumerize :sex, in: [:male, :female], default: :male
+  enumerize :sex, in: [:male, :female]
+end
+
+describe User do
+  it { should enumerize(:sex) }
+
+  # or with RSpec 3 expect syntax
+  it { is_expected.to enumerize(:sex) }
+end
+```
+
+#### Qualifiers
+
+##### in
+
+Use `in` to test usage of the `:in` option.
+
+```ruby
+class User
+  extend Enumerize
+
+  enumerize :sex, in: [:male, :female]
 end
 
 describe User do
   it { should enumerize(:sex).in(:male, :female) }
-  it { should enumerize(:sex).in(:male, :female).with_default(:male) }
+end
+```
 
-  # or with RSpec 3 expect syntax
-  it { is_expected.to enumerize(:sex).in(:male, :female) }
+You can test enumerized attribute value using custom values with the `in`
+qualifier.
+
+```ruby
+class User
+  extend Enumerize
+
+  enumerize :sex, in: { male: 0, female: 1 }
+end
+
+describe User do
+  it { should enumerize(:sex).in(male: 0, female: 1) }
+end
+```
+
+##### with_default
+
+Use `with_default` to test usage of the `:default` option.
+
+```ruby
+class User
+  extend Enumerize
+
+  enumerize :sex, in: [:male, :female], default: :female
+end
+
+describe User do
+  it { should enumerize(:sex).in(:male, :female).default(:female) }
+end
+```
+
+##### with_i18n_scope
+
+Use `with_i18n_scope` to test usage of the `:i18n_scope` option.
+
+```ruby
+class User
+  extend Enumerize
+
+  enumerize :sex, in: [:male, :female], i18n_scope: 'sex'
+end
+
+describe User do
+  it { should enumerize(:sex).in(:male, :female).with_i18n_scope('sex') }
+end
+```
+
+##### with_predicates
+
+Use `with_predicates` to test usage of the `:predicates` option.
+
+```ruby
+class User
+  extend Enumerize
+
+  enumerize :sex, in: [:male, :female], predicates: true
+end
+
+describe User do
+  it { should enumerize(:sex).in(:male, :female).with_predicates(true) }
+end
+```
+
+You can text prefixed predicates with the `with_predicates` qualifiers.
+
+```ruby
+class User
+  extend Enumerize
+
+  enumerize :sex, in: [:male, :female], predicates: { prefix: true }
+end
+
+describe User do
+  it { should enumerize(:sex).in(:male, :female).with_predicates(prefix: true) }
+end
+```
+
+##### with_multiple
+
+Use `with_multiple` to test usage of the `:multiple` option.
+
+```ruby
+class User
+  extend Enumerize
+
+  enumerize :sex, in: [:male, :female], multiple: true
+end
+
+describe User do
+  it { should enumerize(:sex).in(:male, :female).with_multiple(true) }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ en:
         female: "Female"
 ```
 
-You can also pass `i18n_scope` option to specify scope (or array of scopes) storring the translations. Note that `i18n_scope` option does not accept scope as array:
+You can also pass `i18n_scope` option to specify scope (or array of scopes) storing the translations.
 
 
 ```ruby

--- a/lib/enumerize/integrations/rspec/matcher.rb
+++ b/lib/enumerize/integrations/rspec/matcher.rb
@@ -27,6 +27,11 @@ module Enumerize
           self
         end
 
+        def with_multiple(expected_multiple)
+          self.expected_multiple = expected_multiple
+          self
+        end
+
         def failure_message
           "Expected #{expectation}"
         end
@@ -41,6 +46,7 @@ module Enumerize
           description += " with #{expected_default.inspect} as default value" if expected_default
           description += " i18n_scope: #{expected_i18n_scope.inspect}" if expected_i18n_scope
           description += " predicates: #{expected_predicates.inspect}" if expected_predicates
+          description += " multiple: #{expected_multiple.inspect}" if expected_multiple
 
           description
         end
@@ -54,13 +60,14 @@ module Enumerize
           matches &= matches_default_value? if expected_default
           matches &= matches_i18n_scope? if expected_i18n_scope
           matches &= matches_predicates? if expected_predicates
+          matches &= matches_multiple? if expected_multiple
 
           matches
         end
 
         private
         attr_accessor :expected_attr, :expected_values, :subject, :expected_default,
-                      :expected_i18n_scope, :expected_predicates
+                      :expected_i18n_scope, :expected_predicates, :expected_multiple
 
         def expectation
           "#{subject.class.name} to #{description}"
@@ -97,6 +104,10 @@ module Enumerize
           else
             subject.respond_to?("#{expected_attr}_#{attributes.values.first}?")
           end
+        end
+
+        def matches_multiple?
+          subject.instance_variable_defined?("@_#{expected_attr}_enumerized_set")
         end
 
         def sorted_values

--- a/lib/enumerize/integrations/rspec/matcher.rb
+++ b/lib/enumerize/integrations/rspec/matcher.rb
@@ -17,6 +17,11 @@ module Enumerize
           self
         end
 
+        def with_i18n_scope(expected_i18n_scope)
+          self.expected_i18n_scope = expected_i18n_scope
+          self
+        end
+
         def failure_message
           "Expected #{expectation}"
         end
@@ -29,6 +34,7 @@ module Enumerize
           description  = "define enumerize :#{expected_attr}"
           description += " in: #{quote_values(expected_values)}" if expected_values
           description += " with #{expected_default.inspect} as default value" if expected_default
+          description += " i18n_scope: #{expected_i18n_scope.inspect}" if expected_i18n_scope
 
           description
         end
@@ -40,12 +46,14 @@ module Enumerize
           matches &= matches_attribute?
           matches &= matches_values? if expected_values
           matches &= matches_default_value? if expected_default
+          matches &= matches_i18n_scope? if expected_i18n_scope
 
           matches
         end
 
         private
-        attr_accessor :expected_attr, :expected_values, :subject, :expected_default
+        attr_accessor :expected_attr, :expected_values, :subject, :expected_default,
+                      :expected_i18n_scope
 
         def expectation
           "#{subject.class.name} to #{description}"
@@ -70,6 +78,10 @@ module Enumerize
 
         def matches_default_value?
           expected_default == enumerized_default
+        end
+
+        def matches_i18n_scope?
+          attributes.i18n_scope == expected_i18n_scope
         end
 
         def sorted_values

--- a/lib/enumerize/integrations/rspec/matcher.rb
+++ b/lib/enumerize/integrations/rspec/matcher.rb
@@ -22,6 +22,11 @@ module Enumerize
           self
         end
 
+        def with_predicates(expected_predicates)
+          self.expected_predicates = expected_predicates
+          self
+        end
+
         def failure_message
           "Expected #{expectation}"
         end
@@ -35,6 +40,7 @@ module Enumerize
           description += " in: #{quote_values(expected_values)}" if expected_values
           description += " with #{expected_default.inspect} as default value" if expected_default
           description += " i18n_scope: #{expected_i18n_scope.inspect}" if expected_i18n_scope
+          description += " predicates: #{expected_predicates.inspect}" if expected_predicates
 
           description
         end
@@ -47,13 +53,14 @@ module Enumerize
           matches &= matches_values? if expected_values
           matches &= matches_default_value? if expected_default
           matches &= matches_i18n_scope? if expected_i18n_scope
+          matches &= matches_predicates? if expected_predicates
 
           matches
         end
 
         private
         attr_accessor :expected_attr, :expected_values, :subject, :expected_default,
-                      :expected_i18n_scope
+                      :expected_i18n_scope, :expected_predicates
 
         def expectation
           "#{subject.class.name} to #{description}"
@@ -82,6 +89,14 @@ module Enumerize
 
         def matches_i18n_scope?
           attributes.i18n_scope == expected_i18n_scope
+        end
+
+        def matches_predicates?
+          if expected_predicates.is_a?(TrueClass)
+            subject.respond_to?("#{sorted_values.first}?")
+          else
+            subject.respond_to?("#{expected_attr}_#{attributes.values.first}?")
+          end
         end
 
         def sorted_values

--- a/lib/enumerize/integrations/rspec/matcher.rb
+++ b/lib/enumerize/integrations/rspec/matcher.rb
@@ -21,6 +21,10 @@ module Enumerize
           "Expected #{expectation}"
         end
 
+        def failure_message_when_negated
+          "Did not expect #{expectation}"
+        end
+
         def description
           description  = "define enumerize :#{attr} in: #{quote_values(expected_values)}"
           description += " with #{expected_default.inspect} as default value" if expected_default

--- a/spec/enumerize/integrations/rspec/matcher_spec.rb
+++ b/spec/enumerize/integrations/rspec/matcher_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe Enumerize::Integrations::RSpec::Matcher do
           expect(subject).to enumerize(:sex).in(:boy, :girl)
         end.to fail_with(message)
       end
+
+      it 'has the right message when negated' do
+        message = 'Did not expect Model to define enumerize :sex in: "female", "male"'
+        expect do
+          expect(subject).to_not enumerize(:sex).in(:male, :female)
+        end.to fail_with(message)
+      end
     end
 
     context 'defined as hash' do

--- a/spec/enumerize/integrations/rspec/matcher_spec.rb
+++ b/spec/enumerize/integrations/rspec/matcher_spec.rb
@@ -189,4 +189,20 @@ RSpec.describe Enumerize::Integrations::RSpec::Matcher do
       end.to fail_with(message)
     end
   end
+
+  describe '#with_multiple' do
+
+    it 'accepts when has defined the multiple' do
+      model.enumerize(:sex, :in => [:male, :female], multiple: true)
+      expect(subject).to enumerize(:sex).in(:male, :female).with_multiple(true)
+    end
+
+    it 'rejects when has not defined the multiple' do
+      model.enumerize(:sex, :in => [:male, :female])
+      message = 'Expected Model to define enumerize :sex in: "female", "male" multiple: true'
+      expect do
+        expect(subject).to enumerize(:sex).in(:male, :female).with_multiple(true)
+      end.to fail_with(message)
+    end
+  end
 end

--- a/spec/enumerize/integrations/rspec/matcher_spec.rb
+++ b/spec/enumerize/integrations/rspec/matcher_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe Enumerize::Integrations::RSpec::Matcher do
     model.new
   end
 
+  describe 'without qualifier' do
+
+    it 'accepts when has defined a enumerize' do
+      model.enumerize(:sex, :in => [:male, :female])
+      expect(subject).to enumerize(:sex)
+    end
+
+    it 'rejects when has not defined a enumerize' do
+      message = 'Expected Model to define enumerize :sex'
+      expect do
+        expect(subject).to enumerize(:sex)
+      end.to fail_with(message)
+    end
+  end
+
   describe '#in' do
 
     context 'defined as array' do

--- a/spec/enumerize/integrations/rspec/matcher_spec.rb
+++ b/spec/enumerize/integrations/rspec/matcher_spec.rb
@@ -168,4 +168,25 @@ RSpec.describe Enumerize::Integrations::RSpec::Matcher do
       end
     end
   end
+
+  describe '#with_predicates' do
+
+    it 'accepts when predicates is defined as a boolean' do
+      model.enumerize(:sex, :in => [:male, :female], predicates: true)
+      expect(subject).to enumerize(:sex).in(:male, :female).with_predicates(true)
+    end
+
+    it 'accepts when predicates is defined as a hash' do
+      model.enumerize(:sex, :in => [:male, :female], predicates: { prefix: true })
+      expect(subject).to enumerize(:sex).in(:male, :female).with_predicates(prefix: true)
+    end
+
+    it 'rejects when predicates is not defined' do
+      model.enumerize(:sex, :in => [:male, :female])
+      message = 'Expected Model to define enumerize :sex in: "female", "male" predicates: true'
+      expect do
+        expect(subject).to enumerize(:sex).in(:male, :female).with_predicates(true)
+      end.to fail_with(message)
+    end
+  end
 end

--- a/spec/enumerize/integrations/rspec/matcher_spec.rb
+++ b/spec/enumerize/integrations/rspec/matcher_spec.rb
@@ -129,4 +129,43 @@ RSpec.describe Enumerize::Integrations::RSpec::Matcher do
       expect(matcher.description).to eq(message)
     end
   end
+
+  describe '#with_i18n_scope' do
+
+    context 'defined as string' do
+
+      before do
+        model.enumerize(:sex, :in => [:male, :female], i18n_scope: 'sex')
+      end
+
+      it 'accepts the right i18n_scope' do
+        expect(subject).to enumerize(:sex).in(:male, :female).with_i18n_scope('sex')
+      end
+
+      it 'rejects the wrong i18n_scope' do
+        message = 'Expected Model to define enumerize :sex in: "female", "male" i18n_scope: "gender"'
+        expect do
+          expect(subject).to enumerize(:sex).in(:male, :female).with_i18n_scope('gender')
+        end.to fail_with(message)
+      end
+    end
+
+    context 'defined as array' do
+
+      before do
+        model.enumerize(:sex, :in => [:male, :female], i18n_scope: ['sex', 'more.sex'])
+      end
+
+      it 'accepts the wrong i18n_scope' do
+        expect(subject).to enumerize(:sex).in(:male, :female).with_i18n_scope(['sex', 'more.sex'])
+      end
+
+      it 'rejects the wrong i18n_scope' do
+        message = 'Expected Model to define enumerize :sex in: "female", "male" i18n_scope: ["sex"]'
+        expect do
+          expect(subject).to enumerize(:sex).in(:male, :female).with_i18n_scope(['sex'])
+        end.to fail_with(message)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi guys,

I added more qualifiers to the enumerize matcher and some minor fixes too:

- enumerize RSpec matcher now can be negated
- enumerize matcher can be called without any qualifier
- enumerize matcher accepts the with_i18n_scope qualifier
- enumerize matcher accepts the with_multiple qualifier
- Typo fix and coherence about i18n_scope on README
- Add info about qualifiers on README

More info at the commit messages.

I hope you guys enjoy.