### PR TITLE
Add the `with_scope` qualifier to the RSpec enumerize matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ class User
 end
 
 describe User do
-  it { should enumerize(:sex).in(:male, :female).default(:female) }
+  it { should enumerize(:sex).in(:male, :female).with_default(:female) }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -428,6 +428,36 @@ describe User do
 end
 ```
 
+##### with_scope
+
+Use `with_scope` to test usage of the `:scope` option.
+
+```ruby
+class User
+  extend Enumerize
+
+  enumerize :sex, in: [:male, :female], scope: true
+end
+
+describe User do
+  it { should enumerize(:sex).in(:male, :female).with_scope(true) }
+end
+```
+
+You can text custom scope with the `with_scope` qualifiers.
+
+```ruby
+class User
+  extend Enumerize
+
+  enumerize :sex, in: [:male, :female], scope: :having_sex
+end
+
+describe User do
+  it { should enumerize(:sex).in(:male, :female).with_scope(scope: :having_sex) }
+end
+```
+
 ##### with_multiple
 
 Use `with_multiple` to test usage of the `:multiple` option.


### PR DESCRIPTION
Hi guys,

I added the `with_scope` qualifier to the RSpec enumerize matcher this way we can test usage of the `:scope` option and fixed the `with_defaul` qualifier example on README.

I hope you guys enjoy.