### PR TITLE
PG::ProtocolViolation: ERROR: bind message supplies 0 parameters, but prepared statement "" requires 1

### DIFF
--- a/lib/enumerize/scope/activerecord.rb
+++ b/lib/enumerize/scope/activerecord.rb
@@ -22,7 +22,7 @@ module Enumerize
           values = enumerized_attributes[name].find_values(*values).map(&:value)
           values = values.first if values.size == 1
 
-          where(name => values)
+          where(arel_table[name].in(values))
         end
 
         if options[:scope] == true


### PR DESCRIPTION
When using postgresql, this phenomenon occurs.

activerecord 4.2.5
arel 6.0.3
pg 0.18.4
enumerize 1.1.0 

To reproduce:
```ruby
class User < ActiveRecord::Base
  extend Enumerize
  enumerize :sex,  in: [:male, :female], scope: true
end

irb(main):001:0> ActiveRecord::Base.connection.exec_query User.with_sex(:male).arel.to_sql
  SQL (0.8ms)  SELECT "users".* FROM "users" WHERE "users"."sex" = $1
ActiveRecord::StatementInvalid: PG::ProtocolViolation: ERROR:  bind message supplies 0 parameters, but prepared statement "" requires 1
```