### PR TITLE
Rescue MissingAttributeError in the default value setter.

### DIFF
--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -93,26 +93,25 @@ module Enumerize
 
     def _set_default_value_for_enumerized_attributes
       self.class.enumerized_attributes.each do |attr|
-        if respond_to?(attr.name)
-          attr_value = public_send(attr.name)
-        else
-          next
-        end
-
-        value_for_validation = _enumerized_values_for_validation[attr.name.to_s]
-
-        if (!attr_value || attr_value.empty?) && (!value_for_validation || value_for_validation.empty?)
-          value = attr.default_value
-
-          if value.respond_to?(:call)
-            value = value.arity == 0 ? value.call : value.call(self)
+        begin
+          if respond_to?(attr.name)
+            attr_value = public_send(attr.name)
+          else
+            next
           end
 
-          # Rescue when column associated to the enum does not exist.
-          begin
+          value_for_validation = _enumerized_values_for_validation[attr.name.to_s]
+
+          if (!attr_value || attr_value.empty?) && (!value_for_validation || value_for_validation.empty?)
+            value = attr.default_value
+
+            if value.respond_to?(:call)
+              value = value.arity == 0 ? value.call : value.call(self)
+            end
+
             public_send("#{attr.name}=", value)
-          rescue ActiveModel::MissingAttributeError
           end
+        rescue ActiveModel::MissingAttributeError
         end
       end
     end

--- a/test/mongoid_test.rb
+++ b/test/mongoid_test.rb
@@ -65,6 +65,13 @@ describe Enumerize do
     user.role.must_equal 'user'
   end
 
+  it 'does not set default value for not selected attributes' do
+    model.delete_all
+    model.create!(sex: :male)
+
+    assert_equal ['_id'], model.only(:id).first.attributes.keys
+  end
+
   it 'validates inclusion' do
     user = model.new
     user.role = 'wrong'


### PR DESCRIPTION
@lest what do you think? Yeah, it's not that good to rescue it at the end of method and not after specific setter but I think it's much cleaner that way to handle all cases.

fixes #228 