### PR TITLE
replace deprecated alias_method_chain with Module.prepend

### DIFF
--- a/lib/enumerize/hooks/formtastic.rb
+++ b/lib/enumerize/hooks/formtastic.rb
@@ -3,13 +3,8 @@ require 'active_support/concern'
 module Enumerize
   module Hooks
     module FormtasticFormBuilderExtension
-      extend ActiveSupport::Concern
 
-      included do
-        alias_method_chain :input, :enumerize
-      end
-
-      def input_with_enumerize(method, options={})
+      def input(method, options={})
         klass = object.class
 
         if klass.respond_to?(:enumerized_attributes) && (attr = klass.enumerized_attributes[method])
@@ -20,10 +15,10 @@ module Enumerize
           end
         end
 
-        input_without_enumerize(method, options)
+        super(method, options)
       end
     end
   end
 end
 
-::Formtastic::FormBuilder.send :include, Enumerize::Hooks::FormtasticFormBuilderExtension
+::Formtastic::FormBuilder.send :prepend, Enumerize::Hooks::FormtasticFormBuilderExtension

--- a/lib/enumerize/hooks/sequel_dataset.rb
+++ b/lib/enumerize/hooks/sequel_dataset.rb
@@ -1,19 +1,15 @@
 module Enumerize
   module Hooks
     module SequelDataset
-      def self.included(klass)
-        klass.alias_method_chain :literal_append, :enumerize
-      end
-
-      def literal_append_with_enumerize(sql, v)
+      def literal_append(sql, v)
         if v.is_a?(Enumerize::Value)
-          literal_append(sql, v.value)
+          super(sql, v.value)
         else
-          literal_append_without_enumerize(sql, v)
+          super(sql, v)
         end
       end
     end
   end
 end
 
-::Sequel::Dataset.send :include, Enumerize::Hooks::SequelDataset
+::Sequel::Dataset.send :prepend, Enumerize::Hooks::SequelDataset

--- a/lib/enumerize/hooks/simple_form.rb
+++ b/lib/enumerize/hooks/simple_form.rb
@@ -3,21 +3,15 @@ require 'active_support/concern'
 module Enumerize
   module Hooks
     module SimpleFormBuilderExtension
-      extend ActiveSupport::Concern
 
-      included do
-        alias_method_chain :input, :enumerize
-        alias_method_chain :input_field, :enumerize
+      def input(attribute_name, options={}, &block)
+        add_input_options_for_enumerized_attribute(attribute_name, options)
+        super(attribute_name, options, &block)
       end
 
-      def input_with_enumerize(attribute_name, options={}, &block)
+      def input_field(attribute_name, options={})
         add_input_options_for_enumerized_attribute(attribute_name, options)
-        input_without_enumerize(attribute_name, options, &block)
-      end
-
-      def input_field_with_enumerize(attribute_name, options={})
-        add_input_options_for_enumerized_attribute(attribute_name, options)
-        input_field_without_enumerize(attribute_name, options)
+        super(attribute_name, options)
       end
 
       private
@@ -37,4 +31,4 @@ module Enumerize
   end
 end
 
-::SimpleForm::FormBuilder.send :include, Enumerize::Hooks::SimpleFormBuilderExtension
+::SimpleForm::FormBuilder.send :prepend, Enumerize::Hooks::SimpleFormBuilderExtension

--- a/lib/enumerize/hooks/uniqueness.rb
+++ b/lib/enumerize/hooks/uniqueness.rb
@@ -3,21 +3,16 @@ require 'active_support/concern'
 module Enumerize
   module Hooks
     module UniquenessValidator
-      extend ActiveSupport::Concern
 
-      included do
-        alias_method_chain :validate_each, :enumerize
-      end
-
-      def validate_each_with_enumerize(record, name, value)
+      def validate_each(record, name, value)
         if record.class.respond_to?(:enumerized_attributes) && (attr = record.class.enumerized_attributes[name])
           value = attr.find_value(value).try(:value)
         end
 
-        validate_each_without_enumerize(record, name, value)
+        super(record, name, value)
       end
     end
   end
 end
 
-::ActiveRecord::Validations::UniquenessValidator.send :include, Enumerize::Hooks::UniquenessValidator
+::ActiveRecord::Validations::UniquenessValidator.send :prepend, Enumerize::Hooks::UniquenessValidator


### PR DESCRIPTION
This to support Rails 5, which only supports Ruby 2.2.2+

So for older ruby versions there should be some sort of conditional inclusion I guess. Or an older gem version