### PR TITLE
fixed issue #227 When used with globalize-accessors throws ArgumentError

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -19,7 +19,7 @@ module Enumerize
 
     module InstanceMethods
       # https://github.com/brainspec/enumerize/issues/74
-      def write_attribute(attr_name, value)
+      def write_attribute(attr_name, value, *options)
         if self.class.enumerized_attributes[attr_name]
           _enumerized_values_for_validation[attr_name.to_s] = value
         end


### PR DESCRIPTION
fixed issue #277 , compatible with other gems that also override write_attribute method