### PR TITLE
Preserve non-hash usage of ActiveRecord::Base.update_all

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -43,9 +43,11 @@ module Enumerize
     end
 
     def update_all(updates)
-      enumerized_attributes.each do |attr|
-        next if updates[attr.name].blank? || attr.kind_of?(Enumerize::Multiple)
-        updates[attr.name] = attr.find_value(updates[attr.name]).value
+      if updates.is_a?(Hash)
+        enumerized_attributes.each do |attr|
+          next if updates[attr.name].blank? || attr.kind_of?(Enumerize::Multiple)
+          updates[attr.name] = attr.find_value(updates[attr.name]).value
+        end
       end
 
       super(updates)

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -388,4 +388,24 @@ describe Enumerize::ActiveRecordSupport do
     user.reload
     user.status.must_equal 'blocked'
   end
+
+  it 'preserves string usage of update_all' do
+    User.delete_all
+
+    user = User.create(name: "Fred")
+
+    User.update_all("name = 'Frederick'")
+    user.reload
+    user.name.must_equal 'Frederick'
+  end
+
+  it 'preserves interpolated array usage of update_all' do
+    User.delete_all
+
+    user = User.create(name: "Fred")
+
+    User.update_all(["name = :name", {name: 'Frederick'}])
+    user.reload
+    user.name.must_equal 'Frederick'
+  end
 end


### PR DESCRIPTION
The present implementation of update_all breaks when you give it a string argument, or an array argument.  These are both allowed using the AR api and are crucial for doing SQL based updates

For example:

```
   Widget.update_all "position = position + 1"
```

This commit fixes that.