### PR TITLE
Use prepend instead of alias_method_chain

### DIFF
--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -2,18 +2,10 @@ module Enumerize
   module Base
     def self.included(base)
       base.extend ClassMethods
+      base.singleton_class.prepend ClassMethods::Hook
 
       if base.respond_to?(:validate)
         base.validate :_validate_enumerized_attributes
-      end
-
-      class << base
-        if (method_defined?(:inherited) || private_method_defined?(:inherited)) && !private_method_defined?(:inherited_without_enumerized)
-          alias_method :inherited_without_enumerized, :inherited
-          private :inherited_without_enumerized
-        end
-
-        alias_method :inherited, :inherited_with_enumerized
       end
     end
 
@@ -37,11 +29,11 @@ module Enumerize
         @enumerized_attributes ||= AttributeMap.new
       end
 
-      def inherited_with_enumerized(subclass)
+      module Hook
+      def inherited(subclass)
         enumerized_attributes.add_dependant subclass.enumerized_attributes
-        if respond_to?(:inherited_without_enumerized, true)
-          inherited_without_enumerized subclass
-        end
+        super subclass
+      end
       end
 
       private

--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -30,10 +30,10 @@ module Enumerize
       end
 
       module Hook
-      def inherited(subclass)
-        enumerized_attributes.add_dependant subclass.enumerized_attributes
-        super subclass
-      end
+        def inherited(subclass)
+          enumerized_attributes.add_dependant subclass.enumerized_attributes
+          super subclass
+        end
       end
 
       private


### PR DESCRIPTION
Use `prepend` instead of `alias_method_chain` to remove the following warning:
```
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super.
```

Define `ClassMethods::Hook` to override `#inherited` of the specified `Class` instance ( = model class) by `extend Enumerize`.
