### PR TITLE
Allow defining enumerize scopes on child models via  option

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,10 +236,16 @@ User.role.find_value(:admin).value #=> 2
 ActiveRecord scopes:
 
 ```ruby
+class Tweet < ActiveRecord::Base
+  belongs_to :user
+end
+
 class User < ActiveRecord::Base
   extend Enumerize
   enumerize :sex, :in => [:male, :female], scope: true
-  enumerize :status, :in => { active: 1, blocked: 2 }, scope: :having_status
+  enumerize :status, :in => { active: 1, blocked: 2 }, scope: :having_status, has_many_scope: true
+
+  has_many :tweets
 end
 
 User.with_sex(:female)
@@ -250,9 +256,12 @@ User.without_sex(:male)
 
 User.having_status(:blocked).with_sex(:male, :female)
 # SELECT "users".* FROM "users" WHERE "users"."status" IN (2) AND "users"."sex" IN ('male', 'female')
+
+Tweet.with_user_status(:active)
+# SELECT "tweets".* FROM "tweets" INNER JOIN "users" ON "users"."id" = "tweets"."user_id" WHERE "users"."status" = 'active'
 ```
 
-:warning: It is not possible to define a scope when using the `:multiple` option. :warning:
+:warning: It is not possible to define a scope or scope for `has_many` when using the `:multiple` option. :warning:
 
 Array-like attributes with plain ruby objects:
 

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -5,6 +5,7 @@ module Enumerize
     def initialize(klass, name, options={})
       raise ArgumentError, ':in option is required' unless options[:in]
       raise ArgumentError, ':scope option does not work with option :multiple' if options[:multiple] && options[:scope]
+      raise ArgumentError, ':has_many_scope option does not work with option :multiple' if options[:multiple] && options[:has_many_scope]
 
       extend Multiple if options[:multiple]
 

--- a/lib/enumerize/scope/activerecord.rb
+++ b/lib/enumerize/scope/activerecord.rb
@@ -9,8 +9,27 @@ module Enumerize
             if options[:scope]
               _define_activerecord_scope_methods!(name, options)
             end
+
+            if options[:has_many_scope]
+              @enums_with_association_scope ||= {}
+              @enums_with_association_scope[name] = options[:has_many_scope]
+
+              _define_activerecord_children_scope_methods!(name, options)
+            end
           end
         end
+      end
+
+      def has_many(name, scope = nil, options = {}, &extension)
+        if defined?(@enums_with_association_scope) && @enums_with_association_scope.any?
+          @enums_with_association_scope.each do |field, scope_value|
+            parent_association_name = table_name.singularize.to_sym
+            klass = name.to_s.classify.constantize
+            _define_activerecord_child_scope_methods(field, parent_association_name, klass, scope_value)
+          end
+        end
+
+        super
       end
 
       private
@@ -32,6 +51,39 @@ module Enumerize
           end
         end
       end
+
+      def _define_activerecord_children_scope_methods!(field, options)
+        parent_association_name = table_name.singularize.to_sym
+        reflect_on_all_associations(:has_many).each do |association|
+          klass = association.class_name.constantize
+          _define_activerecord_child_scope_methods(field, parent_association_name, klass, options[:has_many_scope])
+        end
+      end
+
+      def _define_activerecord_child_scope_methods(field, parent_association_name, klass, scope_value)
+        parent_klass = self
+
+        scope_name =
+          if scope_value == true
+            "with_#{parent_association_name}_#{field}"
+          else
+            "#{parent_association_name}_options[:scope]"
+          end
+
+        klass.define_singleton_method scope_name do |*values|
+          values = parent_klass.enumerized_attributes[field].find_values(*values).map(&:value)
+          values = values.first if values.size == 1
+          joins(parent_association_name).where(parent_klass.table_name.to_sym => { field => values })
+        end
+
+        if scope_value == true
+          klass.define_singleton_method "without_#{parent_association_name}_#{field}" do |*values|
+            values = parent_klass.enumerized_attributes[field].find_values(*values).map(&:value)
+            joins(parent_association_name).where(parent_klass.arel_table[field].not_in(values))
+          end
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Allow define enumerize scope on child models (`has_many` associations via `has_many_scope`) option, for instance if I have `User` model with many tweets and `has_many_scope` is turned on I can write a query like `Tweet.with_user_status(:active)` instead of `Tweet.joins(:user).where(user: { status: :active })`