### PR TITLE
Support enumerized attributes in #update_all on relation objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### bug fix
 
+* Support enumerized attributes in #update_all on relation objects. (by [@lest](https://github.com/lest))
+
 ## 2.0.0 (August 10, 2016)
 
 ### enhancements

--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -7,6 +7,9 @@ module Enumerize
         if self < ::ActiveRecord::Base
           include InstanceMethods
 
+          const_get(:ActiveRecord_Relation).include(RelationMethods)
+          const_get(:ActiveRecord_AssociationRelation).include(RelationMethods)
+
           # Since Rails use `allocate` method on models and initializes them with `init_with` method.
           # This way `initialize` method is not being called, but `after_initialize` callback always gets triggered.
           after_initialize :_set_default_value_for_enumerized_attributes
@@ -42,16 +45,18 @@ module Enumerize
       end
     end
 
-    def update_all(updates)
-      if updates.is_a?(Hash)
-        enumerized_attributes.each do |attr|
-          next if updates[attr.name].blank? || attr.kind_of?(Enumerize::Multiple)
-          enumerize_value = attr.find_value(updates[attr.name])
-          updates[attr.name] = enumerize_value && enumerize_value.value
+    module RelationMethods
+      def update_all(updates)
+        if updates.is_a?(Hash)
+          enumerized_attributes.each do |attr|
+            next if updates[attr.name].blank? || attr.kind_of?(Enumerize::Multiple)
+            enumerize_value = attr.find_value(updates[attr.name])
+            updates[attr.name] = enumerize_value && enumerize_value.value
+          end
         end
-      end
 
-      super(updates)
+        super(updates)
+      end
     end
   end
 end

--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -9,6 +9,7 @@ module Enumerize
 
           const_get(:ActiveRecord_Relation).include(RelationMethods)
           const_get(:ActiveRecord_AssociationRelation).include(RelationMethods)
+          const_get(:ActiveRecord_Associations_CollectionProxy).include(RelationMethods)
 
           # Since Rails use `allocate` method on models and initializes them with `init_with` method.
           # This way `initialize` method is not being called, but `after_initialize` callback always gets triggered.

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -22,6 +22,7 @@ ActiveRecord::Base.connection.instance_eval do
   create_table :documents do |t|
     t.integer :user_id
     t.string :visibility
+    t.integer :status
     t.timestamps null: true
   end
 end
@@ -35,6 +36,8 @@ end
 
 class Document < BaseEntity
   belongs_to :user
+
+  enumerize :status, in: {draft: 1, release: 2}
 end
 
 module RoleEnum
@@ -430,11 +433,11 @@ describe Enumerize::ActiveRecordSupport do
     Document.delete_all
 
     user = User.create
-    document = Document.create(user: user, visibility: :public)
+    document = Document.create(user: user, status: :draft)
 
-    user.documents.update_all(visibility: :private)
+    user.documents.update_all(status: :release)
     document.reload
-    document.visibility.must_equal 'private'
+    document.status.must_equal 'release'
   end
 
   it 'preserves string usage of update_all' do


### PR DESCRIPTION
Patch only specific delegate classes instead of patching
AR::Relation#update_all globally.