### PR TITLE
Support dumping custom AR type to JSON

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -86,6 +86,10 @@ module Enumerize
       end
 
       alias type_cast_from_database deserialize
+
+      def as_json(options = nil)
+        {attr: @attr.name, subtype: @subtype}.as_json(options)
+      end
     end
   end
 end

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -507,11 +507,14 @@ describe Enumerize::ActiveRecordSupport do
   end
 
   it 'supports AR types serialization' do
-    User.delete_all
-
     type = User.type_for_attribute('status')
     type.must_be_instance_of Enumerize::ActiveRecordSupport::Type
     serialized = type.serialize('blocked')
     serialized.must_equal 2
+  end
+
+  it 'has AR type itself JSON serializable' do
+    type = User.type_for_attribute('status')
+    type.as_json['attr'].must_equal 'status'
   end
 end


### PR DESCRIPTION
There are libraries that dump SQL queries to JSON. In case a record
is created or updated, query bound attributes reference a custom
AR type for enumerized attributes. So it needs to support dumping
to JSON.