### PR TITLE
Extend base class only if it has some concrete ancestors

### DIFF
--- a/lib/enumerize.rb
+++ b/lib/enumerize.rb
@@ -31,17 +31,17 @@ module Enumerize
     base.send :include, Enumerize::Base
     base.extend Enumerize::Predicates
 
-    if defined?(::ActiveRecord::Base)
+    if defined?(::ActiveRecord::Base) && base.ancestors.include?(::ActiveRecord::Base)
       base.extend Enumerize::ActiveRecordSupport
       base.extend Enumerize::Scope::ActiveRecord
     end
 
-    if defined?(::Mongoid::Document)
+    if defined?(::Mongoid::Document) && base.ancestors.include?(::Mongoid::Document)
       base.extend Enumerize::MongoidSupport
       base.extend Enumerize::Scope::Mongoid
     end
 
-    if defined?(::Sequel::Model)
+    if defined?(::Sequel::Model) && base.ancestors.include?(::Sequel::Model)
       base.extend Enumerize::SequelSupport
       base.extend Enumerize::Scope::Sequel
     end


### PR DESCRIPTION
Here is the situation:
I have both AR and Mongoid in my app. So in AR model I'm using `enumerize`. 
I want auto-generated scopes to be provided,  so I pass the `scope` option as well.
```enumerize :status, in: AVAILABLE_STATUSES, predicates: { prefix: true }, scope: true```

But when I trying to use this `with_status` scope, I'm getting 

`NoMethodError: undefined method 'in' for #<Class:0x007feff23e3b10>
from /Users/valeriy/.rvm/gems/ruby-2.2.4/gems/activerecord-3.2.22.5/lib/active_record/dynamic_matchers.rb:55:in 'method_missing'`

I tried to find out why its looking for this `in` method and..

```User.method(:with_status).source_location
=> ["/Users/bernstein/.rvm/gems/ruby-2.2.4/gems/enumerize-0.11.0/lib/enumerize/scope/mongoid.rb", 21]
```

And Voilà! Mongoid patch is there.

That's why I'm proposing this fix.

Please take a look.