### PR TITLE
Fix ci issues (minitest-5.11.x, pg-1.0.0)

### DIFF
--- a/Gemfile.global
+++ b/Gemfile.global
@@ -6,7 +6,7 @@ gem 'rake'
 gem 'rspec', :require => false
 
 gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
-gem 'pg', :platform => [:ruby, :mswin, :mingw]
+gem 'pg', '~> 0.21.0', :platform => [:ruby, :mswin, :mingw]
 gem 'sequel'
 
 platforms :rbx do

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -1,32 +1,32 @@
 require 'test_helper'
 
 describe Enumerize::Base do
-  let(:klass) do
+  let(:kklass) do
     Class.new do
       extend Enumerize
     end
   end
 
   let(:subklass) do
-    Class.new(klass)
+    Class.new(kklass)
   end
 
-  let(:object) { klass.new }
+  let(:object) { kklass.new }
 
   it 'returns nil when not set' do
-    klass.enumerize(:foo, :in => [:a, :b])
+    kklass.enumerize(:foo, :in => [:a, :b])
     object.foo.must_be_nil
   end
 
   it 'returns value that was set' do
-    klass.enumerize(:foo, :in => [:a, :b])
+    kklass.enumerize(:foo, :in => [:a, :b])
     object.foo = :a
     object.foo.must_equal 'a'
   end
 
   it 'returns translation' do
     store_translations(:en, :enumerize => {:foo => {:a => 'a text'}}) do
-      klass.enumerize(:foo, :in => [:a, :b])
+      kklass.enumerize(:foo, :in => [:a, :b])
       object.foo = :a
       object.foo.text.must_equal 'a text'
       object.foo_text.must_equal 'a text'
@@ -36,13 +36,13 @@ describe Enumerize::Base do
 
   it 'returns nil as translation when value is nil' do
     store_translations(:en, :enumerize => {:foo => {:a => 'a text'}}) do
-      klass.enumerize(:foo, :in => [:a, :b])
+      kklass.enumerize(:foo, :in => [:a, :b])
       object.foo_text.must_be_nil
     end
   end
 
   it 'scopes translation by i18n key' do
-    def klass.model_name
+    def kklass.model_name
       name = "ExampleClass"
       def name.i18n_key
         'example_class'
@@ -52,7 +52,7 @@ describe Enumerize::Base do
     end
 
     store_translations(:en, :enumerize => {:example_class => {:foo => {:a => 'a text scoped'}}}) do
-      klass.enumerize(:foo, :in => [:a, :b])
+      kklass.enumerize(:foo, :in => [:a, :b])
       object.foo = :a
       object.foo.text.must_equal 'a text scoped'
       object.foo_text.must_equal 'a text scoped'
@@ -61,88 +61,88 @@ describe Enumerize::Base do
 
   it 'returns humanized value if there are no translations' do
     store_translations(:en, :enumerize => {}) do
-      klass.enumerize(:foo, :in => [:a, :b])
+      kklass.enumerize(:foo, :in => [:a, :b])
       object.foo = :a
       object.foo_text.must_equal 'A'
     end
   end
 
   it 'stores value as string' do
-    klass.enumerize(:foo, :in => [:a, :b])
+    kklass.enumerize(:foo, :in => [:a, :b])
     object.foo = :a
     object.instance_variable_get(:@foo).must_be_instance_of String
   end
 
   it 'handles default value' do
-    klass.enumerize(:foo, :in => [:a, :b], :default => :b)
+    kklass.enumerize(:foo, :in => [:a, :b], :default => :b)
     object.foo.must_equal 'b'
   end
 
   it 'handles default value with lambda' do
-    klass.enumerize(:foo, :in => [:a, :b], :default => lambda { :b })
+    kklass.enumerize(:foo, :in => [:a, :b], :default => lambda { :b })
     object.foo.must_equal 'b'
   end
 
   it 'injects object instance into lamda default value' do
-    klass.enumerize(:foo, :in => [:a, :b], :default => lambda { |obj| :b if obj.is_a? klass })
+    kklass.enumerize(:foo, :in => [:a, :b], :default => lambda { |obj| :b if obj.is_a? kklass })
     object.foo.must_equal 'b'
   end
 
   it 'raises exception on invalid default value' do
     proc {
-      klass.enumerize(:foo, :in => [:a, :b], :default => :c)
+      kklass.enumerize(:foo, :in => [:a, :b], :default => :c)
     }.must_raise ArgumentError
   end
 
   it 'has enumerized attributes' do
-    klass.enumerized_attributes.must_be_empty
-    klass.enumerize(:foo, :in => %w[a b])
-    klass.enumerized_attributes[:foo].must_be_instance_of Enumerize::Attribute
+    kklass.enumerized_attributes.must_be_empty
+    kklass.enumerize(:foo, :in => %w[a b])
+    kklass.enumerized_attributes[:foo].must_be_instance_of Enumerize::Attribute
   end
 
   it "doesn't override existing method" do
-    method = klass.method(:name)
-    klass.enumerize(:name, :in => %w[a b], :default => 'a')
-    klass.method(:name).must_equal method
+    method = kklass.method(:name)
+    kklass.enumerize(:name, :in => %w[a b], :default => 'a')
+    kklass.method(:name).must_equal method
   end
 
   it "inherits enumerized attributes from a parent class" do
-    klass.enumerize(:foo, :in => %w[a b])
+    kklass.enumerize(:foo, :in => %w[a b])
     subklass.enumerized_attributes[:foo].must_be_instance_of Enumerize::Attribute
   end
 
   it "inherits enumerized attributes from a grandparent class" do
-    klass.enumerize(:foo, :in => %w[a b])
+    kklass.enumerize(:foo, :in => %w[a b])
     Class.new(subklass).enumerized_attributes[:foo].must_be_instance_of Enumerize::Attribute
   end
 
   it "doesn't add enumerized attributes to parent class" do
-    klass.enumerize(:foo, :in => %w[a b])
+    kklass.enumerize(:foo, :in => %w[a b])
     subklass.enumerize(:bar, :in => %w[c d])
 
-    klass.enumerized_attributes[:bar].must_be_nil
+    kklass.enumerized_attributes[:bar].must_be_nil
   end
 
   it 'adds new parent class attributes to subclass' do
-    subklass = Class.new(klass)
-    klass.enumerize :foo, :in => %w[a b]
+    subklass = Class.new(kklass)
+    kklass.enumerize :foo, :in => %w[a b]
     subklass.enumerized_attributes[:foo].must_be_instance_of Enumerize::Attribute
   end
 
   it 'stores nil value' do
-    klass.enumerize(:foo, :in => [:a, :b])
+    kklass.enumerize(:foo, :in => [:a, :b])
     object.foo = nil
     object.instance_variable_get(:@foo).must_be_nil
   end
 
   it 'casts value to string for validation' do
-    klass.enumerize(:foo, :in => [:a, :b])
+    kklass.enumerize(:foo, :in => [:a, :b])
     object.foo = :c
     object.read_attribute_for_validation(:foo).must_equal 'c'
   end
 
   it "doesn't cast nil to string for validation" do
-    klass.enumerize(:foo, :in => [:a, :b])
+    kklass.enumerize(:foo, :in => [:a, :b])
     object.foo = nil
     object.read_attribute_for_validation(:foo).must_be_nil
   end
@@ -179,7 +179,7 @@ describe Enumerize::Base do
   end
 
   it 'stores hash values' do
-    klass.enumerize(:foo, :in => {:a => 1, :b => 2})
+    kklass.enumerize(:foo, :in => {:a => 1, :b => 2})
 
     object.foo = :a
     object.instance_variable_get(:@foo).must_equal 1
@@ -191,7 +191,7 @@ describe Enumerize::Base do
   end
 
   it 'returns custom value' do
-    klass.enumerize(:foo, :in => {:a => 1, :b => 2})
+    kklass.enumerize(:foo, :in => {:a => 1, :b => 2})
 
     object.foo = :a
     object.foo_value.must_equal 1

--- a/test/multiple_test.rb
+++ b/test/multiple_test.rb
@@ -1,57 +1,57 @@
 require 'test_helper'
 
 describe Enumerize::Base do
-  let(:klass) do
+  let(:kklass) do
     Class.new do
       extend Enumerize
     end
   end
 
   let(:subklass) do
-    Class.new(klass)
+    Class.new(kklass)
   end
 
-  let(:object) { klass.new }
+  let(:object) { kklass.new }
 
   it 'returns [] when not set' do
-    klass.enumerize :foos, in: %w(a b), multiple: true
+    kklass.enumerize :foos, in: %w(a b), multiple: true
     object.foos.must_equal []
   end
 
   it 'returns setted array' do
-    klass.enumerize :foos, in: %w(a b c), multiple: true
+    kklass.enumerize :foos, in: %w(a b c), multiple: true
     object.foos = %w(a c)
     object.foos.must_equal %w(a c)
   end
 
   it 'sets default value as single value' do
-    klass.enumerize :foos, in: %w(a b c), default: 'b', multiple: true
+    kklass.enumerize :foos, in: %w(a b c), default: 'b', multiple: true
     object.foos.must_equal %w(b)
   end
 
   it 'sets default value as array of one element' do
-    klass.enumerize :foos, in: %w(a b c), default: %w(b), multiple: true
+    kklass.enumerize :foos, in: %w(a b c), default: %w(b), multiple: true
     object.foos.must_equal %w(b)
   end
 
   it 'sets default value as array of several elements' do
-    klass.enumerize :foos, in: %w(a b c), default: %w(b c), multiple: true
+    kklass.enumerize :foos, in: %w(a b c), default: %w(b c), multiple: true
     object.foos.must_equal %w(b c)
   end
 
   it "doesn't define _text method" do
-    klass.enumerize :foos, in: %w(a b c), multiple: true
+    kklass.enumerize :foos, in: %w(a b c), multiple: true
     object.wont_respond_to :foos_text
   end
 
   it "doesn't define _value method" do
-    klass.enumerize :foos, in: %w(a b c), multiple: true
+    kklass.enumerize :foos, in: %w(a b c), multiple: true
     object.wont_respond_to :foos_value
   end
 
   it "cannot define multiple with scope" do
     assert_raises ArgumentError do
-      klass.enumerize :foos, in: %w(a b c), multiple: true, scope: true
+      kklass.enumerize :foos, in: %w(a b c), multiple: true, scope: true
     end
   end
 end

--- a/test/predicates_test.rb
+++ b/test/predicates_test.rb
@@ -1,48 +1,48 @@
 require 'test_helper'
 
 describe Enumerize::Predicates do
-  let(:klass) do
+  let(:kklass) do
     Class.new do
       extend Enumerize
     end
   end
 
-  let(:object) { klass.new }
+  let(:object) { kklass.new }
 
   it 'creates predicate methods' do
-    klass.enumerize(:foo, in: %w(a b), predicates: true)
+    kklass.enumerize(:foo, in: %w(a b), predicates: true)
     object.must_respond_to :a?
     object.must_respond_to :b?
   end
 
   it 'creates predicate methods when enumerized values have dash in it' do
-    klass.enumerize(:foo, in: %w(foo-bar bar-foo), predicates: true)
+    kklass.enumerize(:foo, in: %w(foo-bar bar-foo), predicates: true)
     object.must_respond_to :foo_bar?
     object.must_respond_to :bar_foo?
   end
 
   it 'creates predicate methods on multiple attribute' do
-    klass.enumerize(:foo, in: %w(a b), predicates: true, multiple: true)
+    kklass.enumerize(:foo, in: %w(a b), predicates: true, multiple: true)
     object.must_respond_to :a?
     object.must_respond_to :b?
   end
 
   it 'checks values' do
-    klass.enumerize(:foo, in: %w(a b), predicates: true)
+    kklass.enumerize(:foo, in: %w(a b), predicates: true)
     object.foo = 'a'
     object.a?.must_equal true
     object.b?.must_equal false
   end
 
   it 'checks values on multiple attribute' do
-    klass.enumerize(:foo, in: %w(a b), predicates: true, multiple: true)
+    kklass.enumerize(:foo, in: %w(a b), predicates: true, multiple: true)
     object.foo << :a
     object.a?.must_equal true
     object.b?.must_equal false
   end
 
   it 'prefixes methods' do
-    klass.enumerize(:foo, in: %w(a b), predicates: { prefix: 'bar' })
+    kklass.enumerize(:foo, in: %w(a b), predicates: { prefix: 'bar' })
     object.wont_respond_to :a?
     object.wont_respond_to :b?
     object.must_respond_to :bar_a?
@@ -50,13 +50,13 @@ describe Enumerize::Predicates do
   end
 
   it 'accepts only option' do
-    klass.enumerize(:foo, in: %w(a b), predicates: { only: :a })
+    kklass.enumerize(:foo, in: %w(a b), predicates: { only: :a })
     object.must_respond_to :a?
     object.wont_respond_to :b?
   end
 
   it 'accepts except option' do
-    klass.enumerize(:foo, in: %w(a b), predicates: { except: :a })
+    kklass.enumerize(:foo, in: %w(a b), predicates: { except: :a })
     object.wont_respond_to :a?
     object.must_respond_to :b?
   end

--- a/test/rails_admin_test.rb
+++ b/test/rails_admin_test.rb
@@ -1,24 +1,24 @@
 require 'test_helper'
 
 class RailsAdminSpec < MiniTest::Spec
-  let(:klass) do
+  let(:kklass) do
     Class.new do
       extend Enumerize
     end
   end
 
-  let(:object) { klass.new }
+  let(:object) { kklass.new }
 
   it 'defines enum method' do
     store_translations(:en, :enumerize => {:foo => {:a => 'a text', :b => 'b text'}}) do
-      klass.enumerize(:foo, in: [:a, :b])
+      kklass.enumerize(:foo, in: [:a, :b])
       object.foo_enum.must_equal [['a text', 'a'], ['b text', 'b']]
     end
   end
 
   it 'defines enum properly for custom values enumerations' do
     store_translations(:en, :enumerize => {:foo => {:a => 'a text', :b => 'b text'}}) do
-      klass.enumerize(:foo, in: {:a => 1, :b => 2})
+      kklass.enumerize(:foo, in: {:a => 1, :b => 2})
       object.foo_enum.must_equal [['a text', 'a'], ['b text', 'b']]
     end
   end

--- a/test/set_test.rb
+++ b/test/set_test.rb
@@ -2,17 +2,17 @@ require 'test_helper'
 require 'yaml'
 
 describe Enumerize::Set do
-  let(:klass) do
+  let(:kklass) do
     Class.new do
       extend Enumerize
       enumerize :foo, :in => %w(a b c), :multiple => true
     end
   end
 
-  let(:object) { klass.new }
+  let(:object) { kklass.new }
 
   def build_set(values)
-    @set = Enumerize::Set.new(object, klass.foo, values)
+    @set = Enumerize::Set.new(object, kklass.foo, values)
   end
 
   def set
@@ -39,7 +39,7 @@ describe Enumerize::Set do
   end
 
   it 'equals to other set' do
-    set.must_equal Enumerize::Set.new(nil, klass.foo, %w(a))
+    set.must_equal Enumerize::Set.new(nil, kklass.foo, %w(a))
   end
 
   it 'equals to array' do


### PR DESCRIPTION
Avoid method override error caused by minitest-5.11.x.
After this commit(seattlerb/minitest@00433fc), Minitest::Spec has an instance method that named `klass`.

Rails dose not work with pg-1.0.0
- rails/rails#31673
