### PR TITLE
Support non-ActiveModel objects in SimpleForm/Formtastic integration.

### DIFF
--- a/lib/enumerize/hooks/formtastic.rb
+++ b/lib/enumerize/hooks/formtastic.rb
@@ -5,7 +5,8 @@ module Enumerize
     module FormtasticFormBuilderExtension
 
       def input(method, options={})
-        klass = object && object.to_model.class
+        enumerized_object = convert_to_model(object)
+        klass = enumerized_object.class
 
         if klass.respond_to?(:enumerized_attributes) && (attr = klass.enumerized_attributes[method])
           options[:collection] ||= attr.options

--- a/lib/enumerize/hooks/simple_form.rb
+++ b/lib/enumerize/hooks/simple_form.rb
@@ -17,7 +17,8 @@ module Enumerize
       private
 
       def add_input_options_for_enumerized_attribute(attribute_name, options)
-        klass = object && object.to_model.class
+        enumerized_object = convert_to_model(object)
+        klass = enumerized_object.class
 
         if klass.respond_to?(:enumerized_attributes) && (attr = klass.enumerized_attributes[attribute_name])
           options[:collection] ||= attr.options

--- a/test/formtastic_test.rb
+++ b/test/formtastic_test.rb
@@ -42,6 +42,12 @@ class FormtasticSpec < MiniTest::Spec
     end
   end
 
+  class Registration < Struct.new(:sex)
+    extend Enumerize
+
+    enumerize :sex, in: [:male, :female]
+  end
+
   before { $VERBOSE = nil }
   after  { $VERBOSE = true }
 
@@ -123,6 +129,15 @@ class FormtasticSpec < MiniTest::Spec
     end)
 
     assert_select 'input[type=text]'
+  end
+
+  it 'renders select with enumerized values for non-ActiveModel object' do
+    concat(semantic_form_for(Registration.new, as: 'registration', url: '/') do |f|
+      f.input(:sex)
+    end)
+
+    assert_select 'select option[value=male]'
+    assert_select 'select option[value=female]'
   end
 
   it 'does not affect forms without object' do

--- a/test/simple_form_test.rb
+++ b/test/simple_form_test.rb
@@ -40,6 +40,12 @@ class SimpleFormSpec < MiniTest::Spec
     end
   end
 
+  class Registration < Struct.new(:sex)
+    extend Enumerize
+
+    enumerize :sex, in: [:male, :female]
+  end
+
   let(:user) { User.new }
   let(:post) { Post.new }
 
@@ -127,6 +133,15 @@ class SimpleFormSpec < MiniTest::Spec
     end)
 
     assert_select 'input.string'
+  end
+
+  it 'renders select with enumerized values for non-ActiveModel object' do
+    concat(simple_form_for(Registration.new, as: 'registration', url: '/') do |f|
+      f.input(:sex)
+    end)
+
+    assert_select 'select option[value=male]'
+    assert_select 'select option[value=female]'
   end
 
   it 'does not affect forms without object' do


### PR DESCRIPTION
closes #309 