### PR TITLE
Freeze enumerated values

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -11,16 +11,16 @@ module Enumerize
       @klass  = klass
       @name   = name.to_sym
 
-      value_class = options.fetch(:value_class, Value)
-      @values = Array(options[:in]).map { |v| value_class.new(self, *v) }
-
-      @value_hash = Hash[@values.map { |v| [v.value.to_s, v] }]
-      @value_hash.merge! Hash[@values.map { |v| [v.to_s, v] }]
-
       if options[:i18n_scope]
         raise ArgumentError, ':i18n_scope option accepts only String or Array of strings' unless Array(options[:i18n_scope]).all? { |s| s.is_a?(String) }
         @i18n_scope = options[:i18n_scope]
       end
+
+      value_class = options.fetch(:value_class, Value)
+      @values = Array(options[:in]).map { |v| value_class.new(self, *v).freeze }
+
+      @value_hash = Hash[@values.map { |v| [v.value.to_s, v] }]
+      @value_hash.merge! Hash[@values.map { |v| [v.to_s, v] }]
 
       if options[:default]
         @default_value = find_default_value(options[:default])
@@ -46,9 +46,9 @@ module Enumerize
 
     def i18n_scopes
       @i18n_scopes ||= if i18n_scope
-        scopes = Array(i18n_scope)
+        Array(i18n_scope)
       elsif @klass.respond_to?(:model_name)
-        scopes = ["enumerize.#{@klass.model_name.i18n_key}.#{name}"]
+        ["enumerize.#{@klass.model_name.i18n_key}.#{name}"]
       else
         []
       end

--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -11,10 +11,16 @@ module Enumerize
       @value = value.nil? ? name.to_s : value
 
       super(name.to_s)
+
+      @i18n_keys = @attr.i18n_scopes.map { |s| :"#{s}.#{self}" }
+      @i18n_keys << :"enumerize.defaults.#{@attr.name}.#{self}"
+      @i18n_keys << :"enumerize.#{@attr.name}.#{self}"
+      @i18n_keys << self.underscore.humanize # humanize value if there are no translations
+      @i18n_keys
     end
 
     def text
-      I18n.t(i18n_keys[0], :default => i18n_keys[1..-1])
+      I18n.t(@i18n_keys[0], :default => @i18n_keys[1..-1])
     end
 
     def ==(other)
@@ -29,20 +35,6 @@ module Enumerize
 
     def predicate_call(value)
       value == self
-    end
-
-    def i18n_keys
-      @i18n_keys ||= begin
-        i18n_keys = i18n_scopes
-        i18n_keys << :"enumerize.defaults.#{@attr.name}.#{self}"
-        i18n_keys << :"enumerize.#{@attr.name}.#{self}"
-        i18n_keys << self.underscore.humanize # humanize value if there are no translations
-        i18n_keys
-      end
-    end
-
-    def i18n_scopes
-      @attr.i18n_scopes.map { |s| :"#{s}.#{self}" }
     end
   end
 end

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -263,7 +263,11 @@ describe Enumerize::ActiveRecordSupport do
   it 'stores custom values for multiple attributes' do
     User.delete_all
 
-    klass = Class.new(User)
+    klass = Class.new(User) do
+      def self.name
+        'UserSubclass'
+      end
+    end
     klass.enumerize :interests, in: { music: 0, sports: 1, dancing: 2, programming: 3}, multiple: true
 
     user = klass.new
@@ -433,7 +437,11 @@ describe Enumerize::ActiveRecordSupport do
   it 'allows using update_all for multiple enumerize' do
     User.delete_all
 
-    klass = Class.new(User)
+    klass = Class.new(User) do
+      def self.name
+        'UserSubclass'
+      end
+    end
     klass.enumerize :interests, in: { music: 0, sports: 1, dancing: 2, programming: 3}, multiple: true
 
     user = klass.create(status: :active)

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -14,6 +14,11 @@ describe Enumerize::Attribute do
     attr.values.must_equal %w[a b]
   end
 
+  it 'returns frozen values' do
+    build_attr nil, :foo, :in => [:a, :b]
+    attr.values.map(&:frozen?).must_equal [true, true]
+  end
+
   it 'converts name to symbol' do
     build_attr nil, 'foo', :in => %w[a b]
     attr.name.must_equal :foo

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -2,10 +2,10 @@ require 'test_helper'
 require 'yaml'
 
 describe Enumerize::Value do
-  class Attr < Struct.new(:values)
+  class Attr < Struct.new(:values, :name, :i18n_scopes)
   end
 
-  let(:attr) { Attr.new([]) }
+  let(:attr)  { Attr.new([], "attribute_name", []) }
   let(:val)  { Enumerize::Value.new(attr, 'test_value', 1) }
 
   it 'is a string' do
@@ -30,7 +30,6 @@ describe Enumerize::Value do
   end
 
   describe 'translation' do
-    let(:attr)  { Struct.new(:values, :name, :i18n_scopes).new([], "attribute_name", []) }
 
     it 'uses common translation' do
       store_translations(:en, :enumerize => {:attribute_name => {:test_value => "Common translation"}}) do

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -5,8 +5,8 @@ describe Enumerize::Value do
   class Attr < Struct.new(:values, :name, :i18n_scopes)
   end
 
-  let(:attr)  { Attr.new([], "attribute_name", []) }
-  let(:val)  { Enumerize::Value.new(attr, 'test_value', 1) }
+  let(:attr) { Attr.new([], "attribute_name", []) }
+  let(:val) { Enumerize::Value.new(attr, 'test_value', 1) }
 
   it 'is a string' do
     val.must_be_kind_of String


### PR DESCRIPTION
Enumerized values are mutable and shared across instances which can lead to hard to track down bugs. Consider the following:

```ruby
class User < ActiveRecord::Base
  extend Enumerize

  enumerize :role, in: [:user, :admin], default: :user
end

User.create!(role: :admin)
User.create!(role: :admin)

User.find(1).role.gsub!('ad', 'rad')

# The following returns "radmin" rather than "admin"
User.find(2).role
```

`Enumerize::Value` does memoization in `Enumerize::Value#i18n_keys` which won't work if the object is frozen so I switched the code to eagerly evaluate the `i18n_keys`. I don't think this will cause any performance issues since the `i18n_keys` will only be computed once per enumerated value at class loading time. This change had a bit of test impact since `Enumerize::Attribute#i18n_scopes` doesn't work with anonymous classes.