### PR TITLE
Predicate should return false for a nil value

### DIFF
--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -78,7 +78,7 @@ class User < ActiveRecord::Base
   extend Enumerize
   include RoleEnum
 
-  enumerize :sex, :in => [:male, :female]
+  enumerize :sex, :in => [:male, :female], predicates: true
 
   serialize :interests, Array
   enumerize :interests, :in => [:music, :sports, :dancing, :programming], :multiple => true
@@ -108,6 +108,11 @@ describe Enumerize::ActiveRecordSupport do
     user = User.new
     user.sex = :invalid
     user.sex.must_be_nil
+  end
+
+  it 'returns false if no value is set' do
+    user = User.new
+    user.male?.must_equal false
   end
 
   it 'saves value' do


### PR DESCRIPTION
```
class User
  extend Enumerize

  enumerize :sex, in: %w(male female), predicates: true
end

user = User.new

user.male?   # => false
user.female? # => false
```

Predicate methods should return `false` as per this example.
This comes from https://github.com/brainspec/enumerize/blob/master/lib/enumerize/predicates.rb#L70 where we delegate with `allow_nil`.

Please let me know if this is a valid issue or if you need more information.
If it is a valid issue, I can try working on a fix too.