### PR TITLE
Fix NoMethodError: undefined method `values' for nil:NilClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### bug fix
 
 * Fix issue with ActiveRecord and Mongoid `reload` method when enumberized attributes weren't synced from DB. (by [@nashby](https://github.com/nashby) and [@FunkyloverOne](https://github.com/FunkyloverOne))
+* Fix exception when using predicate methods on enumerized value transformed into invalid value. (by [@guigs](https://github.com/guigs))
 
 ## 2.2.2 (March 6, 2018)
 

--- a/lib/enumerize/predicatable.rb
+++ b/lib/enumerize/predicatable.rb
@@ -15,7 +15,7 @@ module Enumerize
     end
 
     def predicate_method?(method)
-      method[-1] == '?' && @attr.values.include?(method[0..-2])
+      method[-1] == '?' && @attr && @attr.values.include?(method[0..-2])
     end
   end
 end

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -119,6 +119,10 @@ describe Enumerize::Value do
     it "doesn't respond to a method for not existing value" do
       val.wont_respond_to :some_method?
     end
+
+    it "doesn't fail after changed to an invalid value" do
+      val.upcase.wont_respond_to :some_method?
+    end
   end
 
   describe 'serialization' do


### PR DESCRIPTION
Fix `NoMethodError: undefined method 'values' for nil:NilClass` when calling `respond_to?` on a `Enumerize::Value` that has been changed to invalid value.

Fixes https://github.com/brainspec/enumerize/issues/323.