### PR TITLE
add shallow scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### enhancements
 
 * Add ability to skip validations by passing `:skip_validations` option. (by [@chumakoff](https://github.com/chumakoff))
+* Add option `scope: shallow` to extend scopes based on enumerized attribute values (by [@moofkit](https://github.com/moofkit/))
 
 ### bug fix
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,24 @@ User.having_status(:blocked).with_sex(:male, :female)
 # SELECT "users".* FROM "users" WHERE "users"."status" IN (2) AND "users"."sex" IN ('male', 'female')
 ```
 
+Shallow scopes:
+
+Adds named scopes to the class directly
+
+```ruby
+class User < ActiveRecord::Base
+  extend Enumerize
+  enumerize :sex, :in => [:male, :female], scope: :shallow
+  enumerize :status, :in => { active: 1, blocked: 2 }, scope: :shallow
+end
+
+User.male
+# SELECT "users".* FROM "users" WHERE "users"."sex" = 'male'
+
+User.active
+# SELECT "users".* FROM "users" WHERE "users"."status" = 1
+```
+
 :warning: It is not possible to define a scope when using the `:multiple` option. :warning:
 
 Array-like attributes with plain ruby objects:

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -48,6 +48,10 @@ module Enumerize
       values.map { |value| find_value(value) }.compact
     end
 
+    def each_value
+      values.each { |value| yield value }
+    end
+
     def i18n_scopes
       @i18n_scopes ||= if i18n_scope
         Array(i18n_scope)

--- a/lib/enumerize/scope/activerecord.rb
+++ b/lib/enumerize/scope/activerecord.rb
@@ -18,6 +18,8 @@ module Enumerize
       private
 
       def _define_activerecord_scope_methods!(name, options)
+        return _define_activerecord_shallow_scopes!(name) if options[:scope] == :shallow
+
         scope_name = options[:scope] == true ? "with_#{name}" : options[:scope]
 
         define_singleton_method scope_name do |*values|
@@ -31,6 +33,14 @@ module Enumerize
           define_singleton_method "without_#{name}" do |*values|
             values = enumerized_attributes[name].find_values(*values).map(&:value)
             where(arel_table[name].not_in(values))
+          end
+        end
+      end
+
+      def _define_activerecord_shallow_scopes!(attribute_name)
+        enumerized_attributes[attribute_name].each_value do |value_obj|
+          define_singleton_method(value_obj) do
+            where(attribute_name => value_obj.value)
           end
         end
       end

--- a/lib/enumerize/scope/mongoid.rb
+++ b/lib/enumerize/scope/mongoid.rb
@@ -18,6 +18,7 @@ module Enumerize
       private
 
       def _define_mongoid_scope_methods!(name, options)
+        return _define_mongoid_shallow_scopes!(name) if options[:scope] == :shallow
         scope_name = options[:scope] == true ? "with_#{name}" : options[:scope]
 
         define_singleton_method scope_name do |*values|
@@ -29,6 +30,14 @@ module Enumerize
           define_singleton_method "without_#{name}" do |*values|
             values = enumerized_attributes[name].find_values(*values).map(&:value)
             not_in(name => values)
+          end
+        end
+      end
+
+      def _define_mongoid_shallow_scopes!(attribute_name)
+        enumerized_attributes[attribute_name].each_value do |value_obj|
+          define_singleton_method(value_obj) do
+            self.in(attribute_name => value_obj.value)
           end
         end
       end

--- a/lib/enumerize/scope/sequel.rb
+++ b/lib/enumerize/scope/sequel.rb
@@ -20,6 +20,8 @@ module Enumerize
       private
 
       def _define_sequel_scope_methods!(name, options)
+        return _define_sequel_shallow_scopes!(name) if options[:scope] == :shallow
+
         klass = self
         scope_name = options[:scope] == true ? "with_#{name}" : options[:scope]
 
@@ -34,6 +36,14 @@ module Enumerize
           def_dataset_method "without_#{name}" do |*values|
             values = values.map { |value| klass.enumerized_attributes[name].find_value(value).value }
             exclude(name => values)
+          end
+        end
+      end
+
+      def _define_sequel_shallow_scopes!(attribute_name)
+        enumerized_attributes[attribute_name].each_value do |value_obj|
+          def_dataset_method(value_obj) do
+            where(attribute_name => value_obj.value.to_s)
           end
         end
       end

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -45,6 +45,7 @@ ActiveRecord::Base.connection.instance_eval do
     t.string :interests
     t.integer :status
     t.text :settings
+    t.integer :skill
     t.string :account_type, :default => :basic
     t.string :foo
   end
@@ -82,13 +83,15 @@ class User < ActiveRecord::Base
 
   store :settings, accessors: [:language]
 
-  enumerize :sex, :in => [:male, :female]
+  enumerize :sex, :in => [:male, :female], scope: :shallow
   enumerize :language, :in => [:en, :jp]
 
   serialize :interests, Array
   enumerize :interests, :in => [:music, :sports, :dancing, :programming], :multiple => true
 
   enumerize :status, :in => { active: 1, blocked: 2 }, scope: true
+
+  enumerize :skill, :in => { noob: 0, casual: 1, pro: 2 }, scope: :shallow
 
   enumerize :account_type, :in => [:basic, :premium]
 
@@ -358,6 +361,7 @@ describe Enumerize::ActiveRecordSupport do
 
     user_1 = User.create!(status: :active, role: :admin)
     user_2 = User.create!(status: :blocked)
+    user_3 = User.create!(sex: :male, skill: :pro)
 
     User.with_status(:active).must_equal [user_1]
     User.with_status(:blocked).must_equal [user_2]
@@ -366,7 +370,8 @@ describe Enumerize::ActiveRecordSupport do
     User.without_status(:active).must_equal [user_2]
     User.without_status(:active, :blocked).must_equal []
 
-    User.having_role(:admin).must_equal [user_1]
+    User.male.must_equal [user_3]
+    User.pro.must_equal [user_3]
   end
 
   it 'ignores not enumerized values that passed to the scope method' do

--- a/test/sequel_test.rb
+++ b/test/sequel_test.rb
@@ -23,6 +23,7 @@ module SequelTest
     String :name
     String :interests
     String :status
+    Integer :skill
     String :account_type, default: "basic"
     String :foo
   end
@@ -53,11 +54,13 @@ module SequelTest
     plugin :enumerize
     include RoleEnum
 
-    enumerize :sex, :in => [:male, :female]
+    enumerize :sex, :in => [:male, :female], scope: :shallow
 
     enumerize :interests, :in => [:music, :sports, :dancing, :programming], :multiple => true
 
     enumerize :status, :in => { active: 1, blocked: 2 }, scope: true
+
+    enumerize :skill, :in => { noob: 0, casual: 1, pro: 2 }, scope: :shallow
 
     enumerize :account_type, :in => [:basic, :premium]
   end
@@ -256,6 +259,7 @@ module SequelTest
 
       user_1 = User.create(status: :active, role: :admin)
       user_2 = User.create(status: :blocked)
+      user_3 = User.create(sex: :male, skill: :pro)
 
       User.with_status(:active).to_a.must_equal [user_1]
       User.with_status(:blocked).to_a.must_equal [user_2]
@@ -265,6 +269,8 @@ module SequelTest
       User.without_status(:active, :blocked).to_a.must_equal []
 
       User.having_role(:admin).to_a.must_equal [user_1]
+      User.male.to_a.must_equal [user_3]
+      User.pro.to_a.must_equal [user_3]
     end
 
     it 'allows either key or value as valid' do


### PR DESCRIPTION
After migration from outdated [symbolize gem](https://github.com/nofxx/symbolize) I have notice missing `shallow` [feature for scopes](https://github.com/nofxx/symbolize#scopes).
With this option fancy named scopes will be added to the class directly:
```ruby
class User
  extend Enumerize
  enumerize :role, in: [:admin, :customer], scope: :shallow
end

User.admin #=> User.where(role: :admin)
```
[AR enum adds similar scopes too](https://api.rubyonrails.org/v5.2.0/classes/ActiveRecord/Enum.html)

#### :clipboard: TODO:
- [x] implement with AR adapter
- [x] implement with Sequel adapter
- [x] implement with Mongoid adapter
- [x] refactoring
- [x] update docs