### PR TITLE
Add frozen_string_literal pragma

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
 #!/usr/bin/env rake
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 
 require 'rake/testtask'

--- a/lib/enumerize.rb
+++ b/lib/enumerize.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/concern'
 require 'enumerize/version'
 

--- a/lib/enumerize/activemodel.rb
+++ b/lib/enumerize/activemodel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   module ActiveModelAttributesSupport
     def enumerize(name, options={})

--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   module ActiveRecordSupport
     def enumerize(name, options={})

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   class Attribute
     attr_reader :klass, :name, :values, :default_value, :i18n_scope

--- a/lib/enumerize/attribute_map.rb
+++ b/lib/enumerize/attribute_map.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   class AttributeMap
     attr_reader :attributes

--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   module Base
     def self.included(base)

--- a/lib/enumerize/hooks/formtastic.rb
+++ b/lib/enumerize/hooks/formtastic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/concern'
 
 module Enumerize

--- a/lib/enumerize/hooks/sequel_dataset.rb
+++ b/lib/enumerize/hooks/sequel_dataset.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   module Hooks
     module SequelDataset

--- a/lib/enumerize/hooks/simple_form.rb
+++ b/lib/enumerize/hooks/simple_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/concern'
 
 module Enumerize

--- a/lib/enumerize/hooks/uniqueness.rb
+++ b/lib/enumerize/hooks/uniqueness.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/concern'
 
 module Enumerize

--- a/lib/enumerize/integrations/rails_admin.rb
+++ b/lib/enumerize/integrations/rails_admin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   module Integrations
     module RailsAdmin

--- a/lib/enumerize/integrations/rspec.rb
+++ b/lib/enumerize/integrations/rspec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'enumerize/integrations/rspec/matcher'
 
 module Enumerize

--- a/lib/enumerize/integrations/rspec/matcher.rb
+++ b/lib/enumerize/integrations/rspec/matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   module Integrations
     module RSpec

--- a/lib/enumerize/module.rb
+++ b/lib/enumerize/module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   class Module < ::Module
     attr_reader :_class_methods

--- a/lib/enumerize/module_attributes.rb
+++ b/lib/enumerize/module_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   module ModuleAttributes
     def included(base)

--- a/lib/enumerize/mongoid.rb
+++ b/lib/enumerize/mongoid.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   module MongoidSupport
     def enumerize(name, options={})

--- a/lib/enumerize/predicatable.rb
+++ b/lib/enumerize/predicatable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   module Predicatable
     def respond_to_missing?(method, include_private=false)

--- a/lib/enumerize/predicates.rb
+++ b/lib/enumerize/predicates.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/module/delegation'
 
 module Enumerize

--- a/lib/enumerize/scope/activerecord.rb
+++ b/lib/enumerize/scope/activerecord.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   module Scope
     module ActiveRecord

--- a/lib/enumerize/scope/mongoid.rb
+++ b/lib/enumerize/scope/mongoid.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   module Scope
     module Mongoid

--- a/lib/enumerize/scope/sequel.rb
+++ b/lib/enumerize/scope/sequel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   module Scope
     module Sequel

--- a/lib/enumerize/sequel.rb
+++ b/lib/enumerize/sequel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerize
   module SequelSupport
     def enumerize(name, options={})

--- a/lib/enumerize/set.rb
+++ b/lib/enumerize/set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/module/delegation'
 
 module Enumerize

--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'i18n'
 
 module Enumerize

--- a/lib/sequel/plugins/enumerize.rb
+++ b/lib/sequel/plugins/enumerize.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sequel
   module Plugins
     module Enumerize

--- a/spec/enumerize/integrations/rspec/matcher_spec.rb
+++ b/spec/enumerize/integrations/rspec/matcher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_record'
 
 silence_warnings do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails'
 require 'enumerize'
 require 'rspec/matchers/fail_matchers'

--- a/test/activemodel_test.rb
+++ b/test/activemodel_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 if defined?(::ActiveModel::Attributes)

--- a/test/attribute_map_test.rb
+++ b/test/attribute_map_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module Enumerize

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 describe Enumerize::Attribute do

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 describe Enumerize::Base do
@@ -43,7 +45,7 @@ describe Enumerize::Base do
 
   it 'scopes translation by i18n key' do
     def kklass.model_name
-      name = "ExampleClass"
+      name = String.new("ExampleClass")
       def name.i18n_key
         'example_class'
       end

--- a/test/formtastic_test.rb
+++ b/test/formtastic_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 Formtastic::FormBuilder.action_class_finder = Formtastic::ActionClassFinder

--- a/test/module_attributes_test.rb
+++ b/test/module_attributes_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ModuleAttributesSpec < MiniTest::Spec

--- a/test/mongo_mapper_test.rb
+++ b/test/mongo_mapper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 begin

--- a/test/mongoid_test.rb
+++ b/test/mongoid_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 begin

--- a/test/multiple_test.rb
+++ b/test/multiple_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 describe Enumerize::Base do

--- a/test/predicates_test.rb
+++ b/test/predicates_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 describe Enumerize::Predicates do

--- a/test/rails_admin_test.rb
+++ b/test/rails_admin_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RailsAdminSpec < MiniTest::Spec

--- a/test/sequel_test.rb
+++ b/test/sequel_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'sequel'
 require 'logger'

--- a/test/set_test.rb
+++ b/test/set_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'yaml'
 

--- a/test/simple_form_test.rb
+++ b/test/simple_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'simple_form/version'
 

--- a/test/support/mock_controller.rb
+++ b/test/support/mock_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MockController
   attr_writer :action_name
 

--- a/test/support/view_test_helper.rb
+++ b/test/support/view_test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/concern'
 require 'active_support/testing/setup_and_teardown'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'active_support/core_ext/kernel/reporting'

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'yaml'
 


### PR DESCRIPTION
When profiling memory usage in an application that uses the enumerize gem I noticed a large number of string allocations come from [Enumerize::Predicatable::predicate_method?](https://github.com/brainspec/enumerize/blob/master/lib/enumerize/predicatable.rb#L18). This PR adds the `frozen_string_literal: true` pragma to reduce these string allocations throughout the gem for Ruby 2.3+. Other than one test fix, the code changes were done via the [magic_frozen_string_literal](https://github.com/Invoca/magic_frozen_string_literal) gem. If this project adds Rubocop linting, we should consider enabling the `Style/FrozenStringLiteralComment` cop too.