### PR TITLE
Add :skip_validations option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### enhancements
 
+* Add ability to skip validations by passing `:skip_validations` option. (by [@chumakoff](https://github.com/chumakoff))
+
 ### bug fix
 
 * Fix issue with ActiveRecord and Mongoid `reload` method when enumberized attributes weren't synced from DB. (by [@nashby](https://github.com/nashby) and [@FunkyloverOne](https://github.com/FunkyloverOne))

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ class User < ActiveRecord::Base
 end
 ```
 
+:warning: By default, `enumerize` adds `inclusion` validation to the model. You can skip validations by passing `skip_validations` option. :warning:
+
+```ruby
+class User < ActiveRecord::Base
+  extend Enumerize
+
+  enumerize :sex, in: [:male, :female], skip_validations: lambda { |user| user.new_record? }
+
+  enumerize :role, in: [:user, :admin], skip_validations: true
+end
+```
+
 Mongoid:
 
 ```ruby

--- a/lib/enumerize.rb
+++ b/lib/enumerize.rb
@@ -12,6 +12,7 @@ module Enumerize
   autoload :Module,       'enumerize/module'
   autoload :Predicates,   'enumerize/predicates'
   autoload :Predicatable, 'enumerize/predicatable'
+  autoload :Utils,        'enumerize/utils'
   autoload :ModuleAttributes, 'enumerize/module_attributes'
 
   autoload :ActiveModelAttributesSupport, 'enumerize/activemodel'

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -2,7 +2,7 @@
 
 module Enumerize
   class Attribute
-    attr_reader :klass, :name, :values, :default_value, :i18n_scope
+    attr_reader :klass, :name, :values, :default_value, :i18n_scope, :skip_validations_value
 
     def initialize(klass, name, options={})
       raise ArgumentError, ':in option is required' unless options[:in]
@@ -28,6 +28,8 @@ module Enumerize
         @default_value = find_default_value(options[:default])
         raise ArgumentError, 'invalid default value' unless @default_value
       end
+
+      @skip_validations_value = options.fetch(:skip_validations, false)
     end
 
     def find_default_value(value)

--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -74,7 +74,7 @@ module Enumerize
 
     def _validate_enumerized_attributes
       self.class.enumerized_attributes.each do |attr|
-        skip_validations = _call_if_callable(attr.skip_validations_value)
+        skip_validations = Utils.call_if_callable(attr.skip_validations_value, self)
         next if skip_validations
 
         value = read_attribute_for_validation(attr.name)
@@ -101,17 +101,12 @@ module Enumerize
           value_for_validation = _enumerized_values_for_validation[attr.name.to_s]
 
           if (!attr_value || attr_value.empty?) && (!value_for_validation || value_for_validation.empty?)
-            value = _call_if_callable(attr.default_value)
+            value = Utils.call_if_callable(attr.default_value, self)
             public_send("#{attr.name}=", value)
           end
         rescue ActiveModel::MissingAttributeError
         end
       end
-    end
-
-    def _call_if_callable(value)
-      return value unless value.respond_to?(:call)
-      value.arity == 0 ? value.call : value.call(self)
     end
   end
 end

--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -74,6 +74,9 @@ module Enumerize
 
     def _validate_enumerized_attributes
       self.class.enumerized_attributes.each do |attr|
+        skip_validations = _call_if_callable(attr.skip_validations_value)
+        next if skip_validations
+
         value = read_attribute_for_validation(attr.name)
         next if value.blank?
 
@@ -98,17 +101,17 @@ module Enumerize
           value_for_validation = _enumerized_values_for_validation[attr.name.to_s]
 
           if (!attr_value || attr_value.empty?) && (!value_for_validation || value_for_validation.empty?)
-            value = attr.default_value
-
-            if value.respond_to?(:call)
-              value = value.arity == 0 ? value.call : value.call(self)
-            end
-
+            value = _call_if_callable(attr.default_value)
             public_send("#{attr.name}=", value)
           end
         rescue ActiveModel::MissingAttributeError
         end
       end
+    end
+
+    def _call_if_callable(value)
+      return value unless value.respond_to?(:call)
+      value.arity == 0 ? value.call : value.call(self)
     end
   end
 end

--- a/lib/enumerize/sequel.rb
+++ b/lib/enumerize/sequel.rb
@@ -21,7 +21,7 @@ module Enumerize
         super
 
         self.class.enumerized_attributes.each do |attr|
-          skip_validations = _call_if_callable(attr.skip_validations_value)
+          skip_validations = Utils.call_if_callable(attr.skip_validations_value, self)
           next if skip_validations
 
           value = read_attribute_for_validation(attr.name)

--- a/lib/enumerize/sequel.rb
+++ b/lib/enumerize/sequel.rb
@@ -19,8 +19,11 @@ module Enumerize
     module InstanceMethods
       def validate
         super
-        
+
         self.class.enumerized_attributes.each do |attr|
+          skip_validations = _call_if_callable(attr.skip_validations_value)
+          next if skip_validations
+
           value = read_attribute_for_validation(attr.name)
           next if value.blank?
 
@@ -40,13 +43,13 @@ module Enumerize
         if defined?(Sequel::Plugins::Serialization::InstanceMethods)
           modules = self.class.ancestors
           plugin_idx = modules.index(Sequel::Plugins::Serialization::InstanceMethods)
-          
+
           if plugin_idx && plugin_idx < modules.index(Enumerize::SequelSupport::InstanceMethods)
             abort "ERROR: You need to enable the Sequel serialization plugin before calling any enumerize methods on a model."
           end
-          
+
           plugin_idx = modules.index(Sequel::Plugins::ValidationHelpers::InstanceMethods)
-          
+
           if plugin_idx && plugin_idx < modules.index(Enumerize::SequelSupport::InstanceMethods)
             abort "ERROR: You need to enable the Sequel validation_helpers plugin before calling any enumerize methods on a model."
           end

--- a/lib/enumerize/utils.rb
+++ b/lib/enumerize/utils.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Enumerize
+  module Utils
+    class << self
+      def call_if_callable(value, param = nil)
+        return value unless value.respond_to?(:call)
+        value.arity == 0 ? value.call : value.call(param)
+      end
+    end
+  end
+end

--- a/test/mongo_mapper_test.rb
+++ b/test/mongo_mapper_test.rb
@@ -18,9 +18,11 @@ describe Enumerize do
 
     key :sex
     key :role
+    key :foo
 
-    enumerize :sex, :in => %w[male female]
+    enumerize :sex,  :in => %w[male female]
     enumerize :role, :in => %w[admin user], :default => 'user'
+    enumerize :foo,  :in => %w[bar baz], :skip_validations => true
   end
 
   before { $VERBOSE = nil }
@@ -60,6 +62,12 @@ describe Enumerize do
     user = model.new
     user.role = 'wrong'
     user.wont_be :valid?
+  end
+
+  it 'does not validate inclusion when :skip_validations option passed' do
+    user = model.new
+    user.foo = 'wrong'
+    user.must_be :valid?
   end
 
   it 'assigns value on loaded record' do

--- a/test/mongoid_test.rb
+++ b/test/mongoid_test.rb
@@ -20,10 +20,13 @@ describe Enumerize do
 
     field :sex
     field :role
+    field :foo
+
     enumerize :sex,    :in => %w[male female], scope: true
     enumerize :status, :in => %w[notice warning error], scope: true
     enumerize :role,   :in => %w[admin user], :default => 'user', scope: :having_role
     enumerize :mult,   :in => %w[one two three four], :multiple => true
+    enumerize :foo,    :in => %w[bar baz], :skip_validations => true
   end
 
   before { $VERBOSE = nil }
@@ -78,6 +81,12 @@ describe Enumerize do
     user = model.new
     user.role = 'wrong'
     user.wont_be :valid?
+  end
+
+  it 'does not validate inclusion when :skip_validations option passed' do
+    user = model.new
+    user.foo = 'wrong'
+    user.must_be :valid?
   end
 
   it 'sets value to enumerized field from db when record is reloaded' do

--- a/test/support/shared_enums.rb
+++ b/test/support/shared_enums.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'active_record'
+require 'sequel'
+
+module EnumerizeExtention
+  def self.included(base)
+    case
+    when base < ActiveRecord::Base
+      base.extend Enumerize
+    when base < Sequel::Model
+      base.plugin :enumerize
+    end
+  end
+end
+
+module SkipValidationsEnum
+  def self.included(base)
+    base.include EnumerizeExtention
+    base.enumerize :foo, :in => [:bar, :baz], :skip_validations => true
+  end
+end
+
+module DoNotSkipValidationsEnum
+  def self.included(base)
+    base.include EnumerizeExtention
+    base.enumerize :foo, :in => [:bar, :baz], :skip_validations => false
+  end
+end
+
+module SkipValidationsLambdaEnum
+  def self.included(base)
+    base.include EnumerizeExtention
+    base.enumerize :foo, :in => [:bar, :baz], :skip_validations => lambda { true }
+  end
+end
+
+module SkipValidationsLambdaWithParamEnum
+  def self.included(base)
+    base.include EnumerizeExtention
+    base.enumerize :foo, :in => [:bar, :baz], :skip_validations => lambda { |record| true }
+  end
+end


### PR DESCRIPTION
By default, enumerize adds inclusion validation to the model. You can skip validations by passing `:skip_validations` option

https://github.com/brainspec/enumerize/issues/329

```
class User < ActiveRecord::Base
  extend Enumerize

  enumerize :sex, in: [:male, :female], skip_validations: lambda { |user| user.new_record? }

  enumerize :role, in: [:user, :admin], skip_validations: true
end
```