### PR TITLE
Fix sqlite3's version to 1.3.6 series

### DIFF
--- a/Gemfile.global
+++ b/Gemfile.global
@@ -5,7 +5,7 @@ gemspec
 gem 'rake'
 gem 'rspec', :require => false
 
-gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', '~> 1.3.6', :platform => [:ruby, :mswin, :mingw]
 gem 'pg', '~> 0.21.0', :platform => [:ruby, :mswin, :mingw]
 gem 'sequel'
 


### PR DESCRIPTION
I made a PR to fix the version of sqlite3 to 1.3.6 series.
The Rails team also recommends using the 1.3.6 series.

https://github.com/rails/rails/issues/35153

An error has occurred because sqlite3 has been updated to version 1.4.0.
![image](https://user-images.githubusercontent.com/44826653/56629128-55589e80-6687-11e9-9c51-ebc53c11c557.png)

You should be able to build successfully by using sqlite3 version 1.3.6 series.
try it!


