### PR TITLE
Install a bundler compatible with Ruby or Rails version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - gem install "rubygems-update:<3.0.0" --no-document && update_rubygems
   # Bundler 2.0 is not supported by Rails < 5
   - gem list -i bundler -v '>= 2.0.0' && rvm @global do gem uninstall bundler -x || true
-  - gem install bundler -v '~> 1.17'
+  - gem install bundler -v '< 2'
 env:
   global:
     - DB_USER=postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ rvm:
   - 2.4.3
   - 2.5.0
   - jruby-9.1.14.0
+before_install:
+  # Rubygems > 3.0.0 no longer supported rubies < 2.3
+  - gem install "rubygems-update:<3.0.0" --no-document && update_rubygems
+  # Bundler 2.0 is not supported by Rails < 5
+  - gem list -i bundler -v '>= 2.0.0' && rvm @global do gem uninstall bundler -x || true
+  - gem install bundler -v '~> 1.17'
 env:
   global:
     - DB_USER=postgres


### PR DESCRIPTION
This PR is to install bundler compatible with Ruby and Rails version.

It becomes PR to eliminate the following errors.
https://travis-ci.org/brainspec/enumerize/jobs/523821502
![image](https://user-images.githubusercontent.com/12161701/57077971-4e392c80-6d28-11e9-8be5-b43d9cea764b.png)



The version of sqlite3 has been fixed by the following PR.
#337

So, I installed the Bundler corresponding to the version of Ruby or Rails, and modified it to use it.
I just corrected a little about @FunkyloverOne 's PR.
#336
All tests now pass except for an acceptable failure.

I hope you try it.