### PR TITLE
Fix broken test with Rails 5.2

### DIFF
--- a/Gemfile.rails52
+++ b/Gemfile.rails52
@@ -1,7 +1,7 @@
 eval_gemfile('Gemfile.global')
 
 gem 'minitest', '~> 5.8'
-gem 'rails',    '5.2.0.rc1', require: false
+gem 'rails',    '~> 5.2.0', require: false
 gem 'activerecord-jdbcsqlite3-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'master', platform: :jruby
 gem 'activerecord-jdbcpostgresql-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'master', platform: :jruby
 gem 'mongoid',  github: 'mongodb/mongoid'

--- a/test/support/view_test_helper.rb
+++ b/test/support/view_test_helper.rb
@@ -7,10 +7,21 @@ if defined?(ActionView::RoutingUrlFor)
   ActionView::RoutingUrlFor.send(:include, ActionDispatch::Routing::UrlFor)
 end
 
-module ViewTestHelper
+module SetupAndTeardownHelper
   extend ActiveSupport::Concern
 
   include ActiveSupport::Testing::SetupAndTeardown
+
+  included do
+    include ActiveSupport::Callbacks
+    define_callbacks :setup, :teardown
+  end
+end
+
+module ViewTestHelper
+  extend ActiveSupport::Concern
+
+  include SetupAndTeardownHelper
   include ActionView::TestCase::Behavior
 
   included do


### PR DESCRIPTION
Since https://github.com/rails/rails/commit/588150b53c15e96c597d1ab3aac9b78050e7af01,`SetupAndTeardown` module expect to use `prepend`. However, if use `prepend`, it does not work with past versions, so add a wrapper module and modify it to work with `include` in any version.
