### PR TITLE
Test against Rails 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ gemfile:
   - Gemfile.rails42
   - Gemfile.rails50
   - Gemfile.rails52
+  - Gemfile.rails60
   - Gemfile.mongo_mapper
 rvm:
   - 2.2.9
@@ -35,6 +36,12 @@ matrix:
   exclude:
     - gemfile: Gemfile.mongo_mapper
       env: DB=postgresql
+    - rvm: 2.2.9
+      gemfile: Gemfile.rails60
+    - rvm: 2.3.6
+      gemfile: Gemfile.rails60
+    - rvm: 2.4.3
+      gemfile: Gemfile.rails60
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 sudo: false
 services:
-  - postgresql
   - mongodb
+addons:
+  postgresql: 9.3
 gemfile:
   - Gemfile
   - Gemfile.rails42

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gem 'rails',    '5.1.4', require: false
 gem 'activerecord-jdbcsqlite3-adapter', '~> 51.0', platform: :jruby
 gem 'activerecord-jdbcpostgresql-adapter', '~> 51.0', platform: :jruby
 gem 'mongoid'
+gem 'sqlite3', '~> 1.3.6', :platform => [:ruby, :mswin, :mingw]

--- a/Gemfile.global
+++ b/Gemfile.global
@@ -5,7 +5,6 @@ gemspec
 gem 'rake'
 gem 'rspec', :require => false
 
-gem 'sqlite3', '~> 1.3.6', :platform => [:ruby, :mswin, :mingw]
 gem 'pg', '~> 0.21.0', :platform => [:ruby, :mswin, :mingw]
 gem 'sequel'
 

--- a/Gemfile.mongo_mapper
+++ b/Gemfile.mongo_mapper
@@ -5,3 +5,4 @@ gem 'rails',    '4.2.8', :require => false
 gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.0', platform: :jruby
 gem 'activerecord-jdbcpostgresql-adapter', '~> 1.3.0', platform: :jruby
 gem 'mongo_mapper'
+gem 'sqlite3', '~> 1.3.6', :platform => [:ruby, :mswin, :mingw]

--- a/Gemfile.rails42
+++ b/Gemfile.rails42
@@ -5,3 +5,4 @@ gem 'rails',    '4.2.8', :require => false
 gem 'activerecord-jdbcsqlite3-adapter', '~> 1.3.0', platform: :jruby
 gem 'activerecord-jdbcpostgresql-adapter', '~> 1.3.0', platform: :jruby
 gem 'mongoid',  '~> 5.0'
+gem 'sqlite3', '~> 1.3.6', :platform => [:ruby, :mswin, :mingw]

--- a/Gemfile.rails50
+++ b/Gemfile.rails50
@@ -5,3 +5,4 @@ gem 'rails',    '5.0.6', require: false
 gem 'activerecord-jdbcsqlite3-adapter', '~> 51.0', platform: :jruby
 gem 'activerecord-jdbcpostgresql-adapter', '~> 51.0', platform: :jruby
 gem 'mongoid'
+gem 'sqlite3', '~> 1.3.6', :platform => [:ruby, :mswin, :mingw]

--- a/Gemfile.rails60
+++ b/Gemfile.rails60
@@ -1,8 +1,8 @@
 eval_gemfile('Gemfile.global')
 
 gem 'minitest', '~> 5.8'
-gem 'rails',    '~> 5.2.0', require: false
+gem 'rails',    '~> 6.0.0.rc1', require: false
 gem 'activerecord-jdbcsqlite3-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'master', platform: :jruby
 gem 'activerecord-jdbcpostgresql-adapter', github: 'jruby/activerecord-jdbc-adapter', branch: 'master', platform: :jruby
 gem 'mongoid',  github: 'mongodb/mongoid'
-gem 'sqlite3', '~> 1.3.6', :platform => [:ruby, :mswin, :mingw]
+gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]


### PR DESCRIPTION
Also, moved sqlite3 gem to individual gemfiles because Rails 6 requires sqlite3 upper 1.4.0.
Ref: https://github.com/rails/rails/pull/35844