### PR TITLE
do not accesse the constat when the first letter of the attribute is capitalized

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -172,7 +172,7 @@ module Enumerize
 
         def #{name}=(values)
           @_#{name}_enumerized_set = Enumerize::Set.new(self, self.class.enumerized_attributes[:#{name}], values)
-          raw_values = #{name}.values.map(&:value)
+          raw_values = self.#{name}.values.map(&:value)
 
           if defined?(super)
             super raw_values
@@ -184,7 +184,7 @@ module Enumerize
 
           _enumerized_values_for_validation['#{name}'] = values.respond_to?(:map) ? values.reject(&:blank?).map(&:to_s) : values
 
-          #{name}
+          self.#{name}
         end
       RUBY
     end

--- a/test/multiple_test.rb
+++ b/test/multiple_test.rb
@@ -56,4 +56,10 @@ describe Enumerize::Base do
       kklass.enumerize :foos, in: %w(a b c), multiple: true, scope: true
     end
   end
+
+  it 'assign a name with the first letter capitalized' do
+    kklass.enumerize :Foos, in: %w(a b c), multiple: true
+    object.Foos = %w(a c)
+    object.Foos.must_equal %w(a c)
+  end
 end


### PR DESCRIPTION
use case

```rb
class Model
  extend Enumerize

  # mapping of Salesforce like attribute name
  enumerize :Field1__c, in: %w[Web Sns], multipe: true
end
```

When mulitple option is true, an exception `uninitialized constant Field1__c` is raised.
(`#{name}` has become a constant access)
