### PR TITLE
Add and update Ruby versions in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ gemfile:
 rvm:
   - 2.2.9
   - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.4.7
+  - 2.5.6
+  - 2.6.4
   - jruby-9.1.14.0
 before_install:
   # Rubygems > 3.0.0 no longer supported rubies < 2.3
@@ -41,7 +42,7 @@ matrix:
       gemfile: Gemfile.rails60
     - rvm: 2.3.6
       gemfile: Gemfile.rails60
-    - rvm: 2.4.3
+    - rvm: 2.4.7
       gemfile: Gemfile.rails60
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ rvm:
   - 2.2.9
   - 2.3.6
   - 2.4.7
-  - 2.5.6
-  - 2.6.4
+  - 2.5.5
+  - 2.6.3
   - jruby-9.1.14.0
 before_install:
   # Rubygems > 3.0.0 no longer supported rubies < 2.3


### PR DESCRIPTION
Add Ruby version 2.6.4 and update from 2.4.3 and 2.5.0 to 2.4.7 and 2.5.6 in Travis CI.

Reference:
- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-6-4-released/
- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-5-6-released/
- https://www.ruby-lang.org/en/news/2019/08/28/ruby-2-4-7-released/