### PR TITLE
Support Rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
 gemfile:
   - Gemfile
   - Gemfile.rails60
+  - Gemfile.rails61
   - Gemfile.mongo_mapper
 rvm:
   - 2.5.8

--- a/Gemfile.rails61
+++ b/Gemfile.rails61
@@ -1,0 +1,6 @@
+eval_gemfile('Gemfile.global')
+
+gem 'minitest', '~> 5.8'
+gem 'rails',    github: 'rails/rails', branch: '6-1-stable', require: false
+gem 'mongoid',  github: 'mongodb/mongoid'
+gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]

--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -21,8 +21,14 @@ module Enumerize
           require 'enumerize/hooks/uniqueness'
 
           unless options[:multiple]
-            decorate_attribute_type(name, :enumerize) do |subtype|
-              Type.new(enumerized_attributes[name], subtype)
+            if ::ActiveRecord.version >= ::Gem::Version.new("6.1.0.alpha")
+              decorate_attribute_type(name.to_s) do |subtype|
+                Type.new(enumerized_attributes[name], subtype)
+              end
+            else
+              decorate_attribute_type(name, :enumerize) do |subtype|
+                Type.new(enumerized_attributes[name], subtype)
+              end
             end
           end
         end

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -180,7 +180,9 @@ describe Enumerize::ActiveRecordSupport do
     User.delete_all
     User.create!(:sex => :male)
 
-    assert_equal ['id'], User.select(:id).first.attributes.keys
+    user = User.select(:id).first
+    user.attributes['role'].must_equal nil
+    user.attributes['lambda_role'].must_equal nil
   end
 
   it 'has default value with lambda' do


### PR DESCRIPTION
This PR includes the following fixes. 

* Fix for signature changing of `decorate_attribute_type` in Rails 6.1. 
  * Ref: https://github.com/rails/rails/pull/39882、https://github.com/rails/rails/commit/75c309c7ad6517a7fad482f1efd50baadf4bdf45  
* Test against Rails 6.1. 
  * Rails 6.1.0.rc1 has the regression about select tag helper with an array. So this PR runs tests against `6-1-stable` branch. Ref:  [[v6.1.0.rc1] Fix regression for select tag helper with array](https://github.com/rails/rails/pull/40522)
* Fix for broken tests in Rails 6.1.
