### PR TITLE
Fix broken CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: ruby
 sudo: false
 services:
   - mongodb
-  - postgresql
+addons:
+  postgresql: "13"
 gemfile:
   - Gemfile
   - Gemfile.rails60


### PR DESCRIPTION
Currently, PostgreSQL 12 on Focal doesn't work in Travis CI.
Ref: https://travis-ci.community/t/postgresql-broken-on-focal/10371

So I changed to use PostgreSQL 13 instead of 12.