### PR TITLE
add a method to find name from I18n text 

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -83,6 +83,10 @@ module Enumerize
       values.map { |v| [v.text, v.to_s] }
     end
 
+    def find_name(text)
+      options.to_h[text]
+    end
+
     def respond_to_missing?(method, include_private=false)
       @value_hash.include?(method.to_s) || super
     end

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -77,6 +77,15 @@ describe Enumerize::Attribute do
     end
   end
 
+  describe 'find name' do
+    it 'returns the name from the argument text' do
+      store_translations(:en, :enumerize => {:foo => {:a => 'a text', :b => 'b text'}}) do
+        build_attr nil, :foo, :in => %w[a b]
+        attr.find_name('a text').must_equal 'a'
+      end
+    end
+  end
+
   describe 'values hash' do
     before do
       build_attr nil, :foo, :in => {:a => 1, :b => 2}


### PR DESCRIPTION
I have added a method to find the name from I18n text.
The reason is I sometimes need to know attribute name from text when I have to do bulk import from CSV file.

I want to do below.

```ruby
user = User.new(sex: User.sex.find_name('男'))
user.save
```

in 18n
```
ja:
  enumerize:
    user:
      sex:
        male: "男"
        female: "女"
```

```
User.sex.find_name('男')
=> "male"
```