### PR TITLE
`decorate_attribute_type` is removed in Rails 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ gemfile:
   - Gemfile
   - Gemfile.rails60
   - Gemfile.rails61
+  - Gemfile.railsmaster
   - Gemfile.mongo_mapper
 rvm:
   - 2.5.8

--- a/Gemfile.railsmaster
+++ b/Gemfile.railsmaster
@@ -1,0 +1,5 @@
+eval_gemfile('Gemfile.global')
+
+gem 'minitest', '~> 5.8'
+gem 'rails',    github: 'rails/rails', branch: 'main', require: false
+gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]

--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -21,7 +21,11 @@ module Enumerize
           require 'enumerize/hooks/uniqueness'
 
           unless options[:multiple]
-            if ::ActiveRecord.version >= ::Gem::Version.new("6.1.0.alpha")
+            if ::ActiveRecord.version >= ::Gem::Version.new("7.0.0.alpha")
+              attribute(name) do |subtype|
+                Type.new(enumerized_attributes[name], subtype)
+              end
+            elsif ::ActiveRecord.version >= ::Gem::Version.new("6.1.0.alpha")
               decorate_attribute_type(name.to_s) do |subtype|
                 Type.new(enumerized_attributes[name], subtype)
               end


### PR DESCRIPTION
In rails/rails#39929 `decorate_attribute_type` was removed. Now the `attribute` method can also be used to decorate attributes. This PR uses `attribute` instead of `decorate_attribute_type` if the Rails version is `>= 7.0.0.alpha`. I've also added the Rails main branch to the test setup and left monogoid out of the Gemfile. As of now it does not seem to be compatible with Rails 7.  
