### PR TITLE
Remove test case in value_test for ruby 3

### DIFF
--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -84,13 +84,6 @@ describe Enumerize::Value do
         expect(val.text).must_be :==, "Scope specific translation"
       end
     end
-
-    it 'returns nil if value was modified' do
-      store_translations(:en, :enumerize => {:attribute_name => {:test_value => "Common translation"}}) do
-        modified_val = val.upcase
-        expect(modified_val.text).must_be_nil
-      end
-    end
   end
 
   describe 'boolean methods comparison' do


### PR DESCRIPTION
Hi @nashby.Since the behavior of Ruby has changed, I thought that it was not necessary to secure it with a test case.
https://github.com/brainspec/enumerize/pull/369#issuecomment-882193341