### PR TITLE
Prepare for release

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,11 +32,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0.2']
+        ruby-version: ['2.6', '2.7', '3.0.2']
         gemfile:
           - Gemfile
           - Gemfile.rails60
           - Gemfile.rails61
+          - Gemfile.rails70
           - Gemfile.railsmaster
           - Gemfile.mongo_mapper
         db:
@@ -50,8 +51,8 @@ jobs:
             gemfile: Gemfile
           - ruby-version: '3.0.2'
             gemfile: Gemfile.mongo_mapper
-          - ruby-version: '2.5'
-            gemfile: Gemfile.railsmaster
+          - ruby-version: '2.6'
+            gemfile: Gemfile.rails70
           - ruby-version: '2.6'
             gemfile: Gemfile.railsmaster
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## master
+## 2.5.0 (December 24, 2021)
 
 ### enhancements
 

--- a/Gemfile.rails70
+++ b/Gemfile.rails70
@@ -1,0 +1,6 @@
+eval_gemfile('Gemfile.global')
+
+gem 'minitest', '~> 5.8'
+gem 'rails',    github: 'rails/rails', branch: '7-0-stable', require: false
+gem 'mongoid',  github: 'mongodb/mongoid'
+gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]

--- a/Gemfile.rails70
+++ b/Gemfile.rails70
@@ -2,5 +2,8 @@ eval_gemfile('Gemfile.global')
 
 gem 'minitest', '~> 5.8'
 gem 'rails',    github: 'rails/rails', branch: '7-0-stable', require: false
-gem 'mongoid',  github: 'mongodb/mongoid'
+
+# TODO: Mongoid doesn't support Rails 7 yet. Uncomment when it's fixed https://jira.mongodb.org/browse/MONGOID-5193
+# gem 'mongoid',  github: 'mongodb/mongoid'
+
 gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Or install it yourself as:
 
 ## Supported Versions
 
-- Ruby 2.5+
+- Ruby 2.6+
 - Rails 5.2+
 
 ## Usage

--- a/lib/enumerize/version.rb
+++ b/lib/enumerize/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Enumerize
-  VERSION = '2.4.0'
+  VERSION = '2.5.0'
 end

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -38,12 +38,18 @@ silence_warnings do
       'schema_search_path' => 'public'
     }
   }
+
   case db
   when :postgresql
     ActiveRecord::Base.establish_connection(:postgresql_master)
     ActiveRecord::Base.connection.recreate_database('enumerize_test')
   when :mysql2
-    ActiveRecord::Tasks::DatabaseTasks.create ActiveRecord::Base.configurations[db.to_s]
+    if ActiveRecord::Base.configurations.respond_to?(:[])
+      ActiveRecord::Tasks::DatabaseTasks.create ActiveRecord::Base.configurations[db.to_s]
+    else
+      ActiveRecord::Tasks::DatabaseTasks.create ActiveRecord::Base.configurations.find_db_config(db.to_s)
+    end
+
     ActiveRecord::Base.establish_connection(db)
   else
     ActiveRecord::Base.establish_connection(db)


### PR DESCRIPTION
- Test against Rails 7.0 and drop Ruby 2.5 (EOL).
- Bump version.

closes https://github.com/brainspec/enumerize/issues/390