### PR TITLE
fix: usage of kwargs in initialize methods for Ruby 3.x

### DIFF
--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -49,7 +49,7 @@ module Enumerize
       end
     end
 
-    def initialize(*)
+    def initialize(*args, **kwargs)
       super
       _set_default_value_for_enumerized_attributes
     end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -201,4 +201,22 @@ describe Enumerize::Base do
     object.foo = :b
     expect(object.foo_value).must_equal 2
   end
+
+  it 'allows kwargs in Ruby 3.x' do
+    klass = Class.new do
+      include accessors
+      extend Enumerize
+
+      enumerize :foo, :in => %w[test]
+
+      def initialize(argument, key_word_argument: nil)
+        super
+      end
+    end
+
+    expect(proc {
+      klass.new('arg1', key_word_argument: 'kwargs1')
+    }).wont_raise ArgumentError
+
+  end
 end


### PR DESCRIPTION
Without explicitly allowing key word arguments in the intialize methods of ```lib/enumerize/base.rb``` Ruby 3.x >= will raise an ```ArgumentError: wrong number of arguments ...```