### PR TITLE
Allow usage of kwargs with inheritance in Ruby 3.x

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0.2']
+        ruby-version: ['2.7', '3.0.2']
         gemfile:
           - Gemfile
           - Gemfile.rails60
@@ -51,10 +51,6 @@ jobs:
             gemfile: Gemfile
           - ruby-version: '3.0.2'
             gemfile: Gemfile.mongo_mapper
-          - ruby-version: '2.6'
-            gemfile: Gemfile.rails70
-          - ruby-version: '2.6'
-            gemfile: Gemfile.railsmaster
     env:
       BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
       DB: "${{ matrix.db }}"

--- a/enumerize.gemspec
+++ b/enumerize.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Enumerize::VERSION
 
-  gem.required_ruby_version = '>= 1.9.3'
+  gem.required_ruby_version = '>= 2.7'
 
   gem.add_dependency('activesupport', '>= 3.2')
 end

--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -49,7 +49,7 @@ module Enumerize
       end
     end
 
-    def initialize(*)
+    def initialize(*args, **kwargs)
       super
       _set_default_value_for_enumerized_attributes
     end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -201,4 +201,30 @@ describe Enumerize::Base do
     object.foo = :b
     expect(object.foo_value).must_equal 2
   end
+
+  it 'allows initialize method with arguments' do
+    klass = Class.new do
+      extend Enumerize
+
+      def initialize(argument, key_word_argument: nil); end
+    end
+
+    klass.new('arg1', key_word_argument: 'kwargs1')
+  end
+
+  it 'allows initialize method with arguments for inherited classes' do
+    parent_klass = Class.new do
+      def initialize(argument, key_word_argument: nil); end
+    end
+
+    klass = Class.new(parent_klass) do
+      extend Enumerize
+
+      def initialize(argument, key_word_argument: nil)
+        super
+      end
+    end
+
+    klass.new('arg1', key_word_argument: 'kwargs1')
+  end
 end


### PR DESCRIPTION
As described in #400, the changes to how key word arguments are handled in Ruby 3.x lead to ArgumentErrors in Enumerize, when the extended Class uses inheritance combined with key word arguments in the initialize method.

This PR changes the initialize method signature in lib/enumerize/base.rb to allow args and kwargs to fix the described issue. This change however will prevent further support of Ruby Versions < 2.7

- Added specs to make the Issue visible
- Change to initialize mehtod in ```lib/enumerize/base.rb```
- Drop Support for Ruby < 2.7
  - Removed 2.6 from the CI Pipeline
  - Updated gemspec to specify the new minimum Ruby version

This PR resolves #400 
