### PR TITLE
Bug: ActiveRecord attributes have DB values

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -115,11 +115,11 @@ module Enumerize
 
       alias type_cast_for_database serialize
 
-      def deserialize(value)
+      def cast(value)
         @attr.find_value(value)
       end
 
-      alias type_cast_from_database deserialize
+      alias type_cast_from_database cast
 
       def as_json(options = nil)
         {attr: @attr.name, subtype: @subtype}.as_json(options)

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -151,7 +151,7 @@ class SkipValidationsLambdaWithParamUser < ActiveRecord::Base
   include SkipValidationsLambdaWithParamEnum
 end
 
-describe Enumerize::ActiveRecordSupport do
+class Enumerize::ActiveRecordSupportSpec < MiniTest::Spec
   it 'sets nil if invalid value is passed' do
     user = User.new
     user.sex = :invalid
@@ -244,6 +244,15 @@ describe Enumerize::ActiveRecordSupport do
     expect(user.interests).must_equal %w[music]
     user.reload
     expect(user.interests).must_equal %w[music dancing]
+  end
+
+  it 'has enumerized values in active record attributes after reload' do
+    User.delete_all
+    user = User.new
+    user.status = :blocked
+    user.save!
+    user.reload
+    expect(user.attributes["status"]).must_equal 'blocked'
   end
 
   it 'validates inclusion when using write_attribute with string attribute' do


### PR DESCRIPTION
How to reproduce (there's a spec that demonstrates this)

1. Add an enumerized field that is an integer in the DB and a string in code. e.g. the user status in tests
2. Set the enumerized field using the string value
3. Reload the AR object
4. Note that the attributes hash will return the integer DB value not the string

This is a regression from enumerize version 2.2.2. To be specific, this bug was introduced with this
PR https://github.com/brainspec/enumerize/pull/321, when a reload method was defined.

It seems that Rails calls Type#cast and this gem has not defined that method.
Defining cast resolves the issue. Type#deserialize by default calls Type#cast so removing that
definition should be ok.