### PR TITLE
Fix Enumerize with string store accessor keys

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -70,7 +70,7 @@ module Enumerize
           begin
             # Checks first if the enumerized attribute is in ActiveRecord::Store
             store_attr, _ = reloaded.class.stored_attributes.detect do |_store_attr, keys|
-              keys.include?(attr.name)
+              keys.map(&:to_s).include?(attr.name.to_s)
             end
 
             if store_attr.present?

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -101,10 +101,11 @@ class User < ActiveRecord::Base
   extend Enumerize
   include RoleEnum
 
-  store :settings, accessors: [:language]
+  store :settings, accessors: [:language, 'country_code']
 
   enumerize :sex, :in => [:male, :female], scope: :shallow
   enumerize :language, :in => [:en, :jp]
+  enumerize :country_code, :in => [:us, :ca]
 
   serialize :interests, Array
   enumerize :interests, :in => [:music, :sports, :dancing, :programming], :multiple => true
@@ -189,6 +190,15 @@ describe Enumerize::ActiveRecordSupport do
     user.save!
     user.reload
     expect(user.language).must_equal 'en'
+  end
+
+  it 'saves stored attribute value for store accessor with string key' do
+    User.delete_all
+    user = User.new
+    user.country_code = :us
+    user.save!
+    user.reload
+    expect(user.country_code).must_equal 'us'
   end
 
   it 'has default value' do


### PR DESCRIPTION
Ensures Enumerize is agnostic to whether the key to a store accessor is a
string or symbol