### PR TITLE
Add `Enumerize::Attribute#value?` method

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -52,6 +52,10 @@ module Enumerize
       values.each { |value| yield value }
     end
 
+    def value?(value)
+      values.include?(value)
+    end
+
     def i18n_scopes
       @i18n_scopes ||= if i18n_scope
         Array(i18n_scope)

--- a/lib/enumerize/predicatable.rb
+++ b/lib/enumerize/predicatable.rb
@@ -17,7 +17,7 @@ module Enumerize
     end
 
     def predicate_method?(method)
-      method[-1] == '?' && @attr && @attr.values.include?(method[0..-2])
+      method[-1] == '?' && @attr && @attr.value?(method[0..-2])
     end
   end
 end


### PR DESCRIPTION
This PR adds `Enumerize::Attribute#value?` method.

## Summary

This new method prevents the following breakage when autocorrecting with `Performance/InefficientHashSearch` cop.

```diff
-enumerize_attr.values.include?('attr')
+enumerize_attr.value?('attr') #=> ArgumentError: wrong number of arguments (given 2, expected 1)
```

The intention is to add a compatible API for the above, as it does not actually improve performance.

And this method is also used in `Enumerize::Predicates#predicate_method?`, so the enumerize's test also calls it.

## Other Information

About `Performance/InefficientHashSearch` cop:

```ruby
# bad
{ a: 1, b: 2 }.values.include?('garbage')

# good
{ a: 1, b: 2 }.value?('garbage')
```

https://docs.rubocop.org/rubocop-performance/1.14/cops_performance.html#performanceinefficienthashsearch