### PR TITLE
Use class inheritance to define Minitest specs.

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -122,7 +122,7 @@ module Enumerize
       alias type_cast_from_database deserialize
 
       def as_json(options = nil)
-        {attr: @attr.name, subtype: @subtype}.as_json(options)
+        {attr: @attr.name}.as_json(options)
       end
 
       def encode_with(coder)

--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -90,22 +90,26 @@ module Enumerize
 
     def _set_default_value_for_enumerized_attributes
       self.class.enumerized_attributes.each do |attr|
-        next if attr.default_value.nil?
-        begin
-          if respond_to?(attr.name)
-            attr_value = public_send(attr.name)
-          else
-            next
-          end
+        _set_default_value_for_enumerized_attribute(attr)
+      end
+    end
 
-          value_for_validation = _enumerized_values_for_validation[attr.name.to_s]
-
-          if (!attr_value || attr_value.empty?) && (!value_for_validation || value_for_validation.empty?)
-            value = Utils.call_if_callable(attr.default_value, self)
-            public_send("#{attr.name}=", value)
-          end
-        rescue ActiveModel::MissingAttributeError
+    def _set_default_value_for_enumerized_attribute(attr)
+      return if attr.default_value.nil?
+      begin
+        if respond_to?(attr.name)
+          attr_value = public_send(attr.name)
+        else
+          return
         end
+
+        value_for_validation = _enumerized_values_for_validation[attr.name.to_s]
+
+        if (!attr_value || attr_value.empty?) && (!value_for_validation || value_for_validation.empty?)
+          value = Utils.call_if_callable(attr.default_value, self)
+          public_send("#{attr.name}=", value)
+        end
+      rescue ActiveModel::MissingAttributeError
       end
     end
   end

--- a/lib/enumerize/mongoid.rb
+++ b/lib/enumerize/mongoid.rb
@@ -24,6 +24,13 @@ module Enumerize
 
         reloaded
       end
+
+      private
+
+      def _set_default_value_for_enumerized_attribute(attr)
+        super
+      rescue Mongoid::Errors::AttributeNotLoaded
+      end
     end
   end
 end

--- a/test/activemodel_test.rb
+++ b/test/activemodel_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 if defined?(::ActiveModel::Attributes)
 
-describe Enumerize do
+class ActiveModelTest < MiniTest::Spec
   class ActiveModelUser
     include ActiveModel::Model
     include ActiveModel::Attributes

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -8,6 +8,9 @@ db = (ENV['DB'] || 'sqlite3').to_sym
 
 silence_warnings do
   ActiveRecord::Migration.verbose = false
+  if ActiveRecord::Base.respond_to?(:use_yaml_unsafe_load)
+    ActiveRecord::Base.use_yaml_unsafe_load = true
+  end
   ActiveRecord::Base.logger = Logger.new(nil)
   ActiveRecord::Base.configurations = {
     'sqlite3' => {
@@ -511,7 +514,7 @@ class ActiveRecordTest < MiniTest::Spec
     user = User.create(:status => :active)
     user.status = :blocked
 
-    assert_equal [1, 2], YAML.load(user.changes.to_yaml)[:status]
+    assert_equal [1, 2], unsafe_yaml_load(user.changes.to_yaml)[:status]
   end
 
   it 'does not change by the practical same value' do
@@ -630,7 +633,7 @@ class ActiveRecordTest < MiniTest::Spec
   end
 
   it "doesn't break YAML serialization" do
-    user = YAML.load(User.create(status: :blocked).to_yaml)
+    user = unsafe_yaml_load(User.create(status: :blocked).to_yaml)
     expect(user.status).must_equal 'blocked'
   end
 

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -151,7 +151,7 @@ class SkipValidationsLambdaWithParamUser < ActiveRecord::Base
   include SkipValidationsLambdaWithParamEnum
 end
 
-describe Enumerize::ActiveRecordSupport do
+class ActiveRecordTest < MiniTest::Spec
   it 'sets nil if invalid value is passed' do
     user = User.new
     user.sex = :invalid

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-describe Enumerize::Attribute do
+class AttributeTest < MiniTest::Spec
   def attr
     @attr ||= nil
   end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-describe Enumerize::Base do
+class BaseTest < MiniTest::Spec
   let(:kklass) do
     Class.new do
       extend Enumerize

--- a/test/mongo_mapper_test.rb
+++ b/test/mongo_mapper_test.rb
@@ -10,7 +10,7 @@ end
 
 MongoMapper.connection = Mongo::Client.new(['localhost:27017'], database: 'enumerize-test-suite-of-mongomapper')
 
-describe Enumerize do
+class MongoMapperTest < MiniTest::Spec
   class MongoMapperUser
     include MongoMapper::Document
     extend Enumerize

--- a/test/mongoid_test.rb
+++ b/test/mongoid_test.rb
@@ -13,7 +13,7 @@ Mongoid.configure do |config|
   config.options = { use_utc: true, include_root_in_json: true }
 end
 
-describe Enumerize do
+class MongoidTest < MiniTest::Spec
   class MongoidUser
     include Mongoid::Document
     extend Enumerize

--- a/test/multiple_test.rb
+++ b/test/multiple_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-describe Enumerize::Base do
+class MultipleTest < MiniTest::Spec
   let(:kklass) do
     Class.new do
       extend Enumerize

--- a/test/predicates_test.rb
+++ b/test/predicates_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-describe Enumerize::Predicates do
+class PredicatesTest < MiniTest::Spec
   let(:kklass) do
     Class.new do
       extend Enumerize

--- a/test/set_test.rb
+++ b/test/set_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 require 'yaml'
 
-describe Enumerize::Set do
+class SetTest < MiniTest::Spec
   let(:kklass) do
     Class.new do
       extend Enumerize

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,6 +46,14 @@ module MiscHelpers
       I18n.reload!
     end
   end
+
+  def unsafe_yaml_load(yaml)
+    if YAML.respond_to?(:unsafe_load)
+      YAML.unsafe_load(yaml)
+    else
+      YAML.load(yaml)
+    end
+  end
 end
 
 class MiniTest::Spec

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 require 'yaml'
 
-describe Enumerize::Value do
+class ValueTest < MiniTest::Spec
   class Model
   end
 


### PR DESCRIPTION
https://github.com/brainspec/enumerize/commit/28dd2247ec03ef9a7e74266060d443ed8df1c2b4 this commit introduced an issue where `Minitest` specs that were defined with `describe` weren't running. I couldn't figure out what's the reason but since we use both `RSpec` and `Minitest` it's better to stick to separate spec definitions.