### PR TITLE
Make sure we rescue Mongoid::Errors::AttributeNotLoaded.

### DIFF
--- a/lib/enumerize/base.rb
+++ b/lib/enumerize/base.rb
@@ -90,22 +90,26 @@ module Enumerize
 
     def _set_default_value_for_enumerized_attributes
       self.class.enumerized_attributes.each do |attr|
-        next if attr.default_value.nil?
-        begin
-          if respond_to?(attr.name)
-            attr_value = public_send(attr.name)
-          else
-            next
-          end
+        _set_default_value_for_enumerized_attribute(attr)
+      end
+    end
 
-          value_for_validation = _enumerized_values_for_validation[attr.name.to_s]
-
-          if (!attr_value || attr_value.empty?) && (!value_for_validation || value_for_validation.empty?)
-            value = Utils.call_if_callable(attr.default_value, self)
-            public_send("#{attr.name}=", value)
-          end
-        rescue ActiveModel::MissingAttributeError
+    def _set_default_value_for_enumerized_attribute(attr)
+      return if attr.default_value.nil?
+      begin
+        if respond_to?(attr.name)
+          attr_value = public_send(attr.name)
+        else
+          return
         end
+
+        value_for_validation = _enumerized_values_for_validation[attr.name.to_s]
+
+        if (!attr_value || attr_value.empty?) && (!value_for_validation || value_for_validation.empty?)
+          value = Utils.call_if_callable(attr.default_value, self)
+          public_send("#{attr.name}=", value)
+        end
+      rescue ActiveModel::MissingAttributeError
       end
     end
   end

--- a/lib/enumerize/mongoid.rb
+++ b/lib/enumerize/mongoid.rb
@@ -24,6 +24,13 @@ module Enumerize
 
         reloaded
       end
+
+      private
+
+      def _set_default_value_for_enumerized_attribute(attr)
+        super
+      rescue Mongoid::Errors::AttributeNotLoaded
+      end
     end
   end
 end


### PR DESCRIPTION
It's an error Mongoid throws when Enumerize is trying to set default value for enumerized attribute that wasn't loaded:

```
Mongoid::Errors::AttributeNotLoaded:
message:
  Attempted to access attribute 'role' on MongoidTest::MongoidUser which was not loaded.
```