### PR TITLE
ActiveModel::Type#as_json was removed from Rails master.

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -122,7 +122,7 @@ module Enumerize
       alias type_cast_from_database deserialize
 
       def as_json(options = nil)
-        {attr: @attr.name, subtype: @subtype}.as_json(options)
+        {attr: @attr.name}.as_json(options)
       end
 
       def encode_with(coder)


### PR DESCRIPTION
Because it wasn't providing any useful info and was a bit misleading since json output was the same for all types.

I think we can keep our `as_json` method but just remove `subtype` from it.