### PR TITLE
Warn about already defined predicate method only when it's true.

### DIFF
--- a/lib/enumerize/predicates.rb
+++ b/lib/enumerize/predicates.rb
@@ -69,7 +69,21 @@ module Enumerize
       end
 
       def build(klass)
+        warn_on_already_defined_methods
+
         klass.delegate(*names, to: @attr.name, prefix: @options[:prefix], allow_nil: true)
+      end
+
+      def warn_on_already_defined_methods
+        names.each do |name|
+          method_name = [@options[:prefix], name].compact.join('_')
+
+          if @attr.klass.respond_to?(method_name)
+            warn(
+              "Predicate method `#{name}` is already defined as #{@attr.klass.name}##{name}. Use enumerize's :prefix option to avoid it"
+            )
+          end
+        end
       end
     end
   end

--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -10,10 +10,6 @@ module Enumerize
     attr_reader :value
 
     def initialize(attr, name, value=nil)
-      if self.class.method_defined?("#{name}?")
-        warn("It's not recommended to use `#{name}` as a field value since `#{name}?` is defined. (#{attr.klass.name}##{attr.name})")
-      end
-
       @attr  = attr
       @value = value.nil? ? name.to_s : value
 

--- a/test/predicates_test.rb
+++ b/test/predicates_test.rb
@@ -6,6 +6,8 @@ class PredicatesTest < MiniTest::Spec
   let(:kklass) do
     Class.new do
       extend Enumerize
+
+      def self.c?; end
     end
   end
 
@@ -61,5 +63,23 @@ class PredicatesTest < MiniTest::Spec
     kklass.enumerize(:foo, in: %w(a b), predicates: { except: :a })
     expect(object).wont_respond_to :a?
     expect(object).must_respond_to :b?
+  end
+
+  it 'warns if predicate method is already defined' do
+    assert_output(nil, /`c\?` is already defined/) do
+      kklass.enumerize(:bar, in: %w(a b c), predicates: true)
+    end
+  end
+
+  it 'does not warn if predicate has prefix and does not collide with defined method' do
+    assert_output(nil, '') do
+      kklass.enumerize(:bar, in: %w(a b c), predicates: { prefix: 'bar' })
+    end
+  end
+
+  it 'does not warn if predicate method is already defined but enumerize does not generate predicates' do
+    assert_output(nil, '') do
+      kklass.enumerize(:bar, in: %w(a b c))
+    end
   end
 end

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -153,9 +153,5 @@ class ValueTest < MiniTest::Spec
     it 'no output if undefined boolean method' do
       assert_silent() { Enumerize::Value.new(attr, 'test_value') }
     end
-
-    it 'error output if defined boolean method' do
-      assert_output(nil, /`empty\?` is defined/) { Enumerize::Value.new(attr, 'empty') }
-    end
   end
 end


### PR DESCRIPTION
Previously we were warning even if `predicate` feature wasn't used at all.

Closes https://github.com/brainspec/enumerize/issues/411