### PR TITLE
Add support for procs as `i18n_scope` option value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ class Person
 
   enumerize :status, in: %w[student employed retired], i18n_scope: "status"
   enumerize :roles, in: %w[user admin], i18n_scope: ["user.roles", "roles"]
+  enumerize :color, in: %w[green blue], i18n_scope: proc { |value| "color" }
 end
 
 # localization file

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -12,11 +12,7 @@ module Enumerize
 
       @klass  = klass
       @name   = name.to_sym
-
-      if options[:i18n_scope]
-        raise ArgumentError, ':i18n_scope option accepts only String or Array of strings' unless Array(options[:i18n_scope]).all? { |s| s.is_a?(String) }
-        @i18n_scope = options[:i18n_scope]
-      end
+      @i18n_scope = options[:i18n_scope]
 
       value_class = options.fetch(:value_class, Value)
       @values = Array(options[:in]).map { |v| value_class.new(self, *v).freeze }

--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -15,7 +15,11 @@ module Enumerize
 
       super(name.to_s)
 
-      @i18n_keys = @attr.i18n_scopes.map { |s| :"#{s}.#{self}" }
+      @i18n_keys = @attr.i18n_scopes.map do |s|
+        scope = Utils.call_if_callable(s, @value)
+
+        :"#{scope}.#{self}"
+      end
       @i18n_keys << :"enumerize.defaults.#{@attr.name}.#{self}"
       @i18n_keys << :"enumerize.#{@attr.name}.#{self}"
       @i18n_keys << ActiveSupport::Inflector.humanize(ActiveSupport::Inflector.underscore(self)) # humanize value if there are no translations

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -37,10 +37,6 @@ class AttributeTest < MiniTest::Spec
       build_attr nil, 'foo', :in => %w[a b], :i18n_scope => %w[bar buzz]
       expect(attr.i18n_scopes).must_equal %w[bar buzz]
     end
-
-    it 'accepts only string scopes' do
-      expect(proc { build_attr nil, 'foo', :in => %w[a b], :i18n_scope => [%w[bar buzz], "bar.buzz"] }).must_raise ArgumentError
-    end
   end
 
   describe 'options for select' do

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -87,6 +87,14 @@ class ValueTest < MiniTest::Spec
         expect(val.text).must_be :==, "Scope specific translation"
       end
     end
+
+    it 'allows to pass a proc as i18n_scopes param' do
+      attr.i18n_scopes = [proc { |v| "other.scope.#{v}" }]
+
+      store_translations(:en, :other => {:scope => {:"1" => {:test_value => "Scope specific translation"}}}) do
+        expect(val.text).must_be :==, "Scope specific translation"
+      end
+    end
   end
 
   describe 'boolean methods comparison' do


### PR DESCRIPTION
Closes https://github.com/brainspec/enumerize/issues/406