### PR TITLE
Define Type#cast instead of deserialize to fix serialization issue.

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -115,11 +115,11 @@ module Enumerize
 
       alias type_cast_for_database serialize
 
-      def deserialize(value)
+      def cast(value)
         @attr.find_value(value)
       end
 
-      alias type_cast_from_database deserialize
+      alias type_cast_from_database cast
 
       def as_json(options = nil)
         {attr: @attr.name}.as_json(options)

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -249,6 +249,15 @@ class ActiveRecordTest < MiniTest::Spec
     expect(user.interests).must_equal %w[music dancing]
   end
 
+  it 'has enumerized values in active record attributes after reload' do
+    User.delete_all
+    user = User.new
+    user.status = :blocked
+    user.save!
+    user.reload
+    expect(user.attributes["status"]).must_equal 'blocked'
+  end
+
   it 'validates inclusion when using write_attribute with string attribute' do
     user = User.new
     user.send(:write_attribute, 'role', 'wrong')


### PR DESCRIPTION
Type#deserialize by default calls Type#cast so we can keep one.

Closes https://github.com/brainspec/enumerize/pull/404