### PR TITLE
Allow `#becomes` to target a non-`Enumerize` AR model

### DIFF
--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -100,7 +100,11 @@ module RoleEnum
   enumerize :lambda_role, :in => [:user, :admin], :default => lambda { :admin }
 end
 
-class User < ActiveRecord::Base
+class BaseUser < ActiveRecord::Base
+  self.table_name = 'users'
+end
+
+class User < BaseUser
   extend Enumerize
   include RoleEnum
 
@@ -488,6 +492,18 @@ class ActiveRecordTest < MiniTest::Spec
     uniq_user.valid?
 
     expect(uniq_user.errors).must_be_empty
+  end
+
+  it 'allows an object to #becomes a non-Enumerize model' do
+    User.delete_all
+    user = User.new
+    user.sex = :male
+    user.save!
+
+    base_user = User.find(user.id).becomes(BaseUser)
+    base_user.valid?
+
+    expect(base_user.errors).must_be_empty
   end
 
   it 'supports multiple attributes in #becomes' do


### PR DESCRIPTION
This causes the `#becomes` patch to work when converting a subclassed **Enumerize**-enabled model into a non-**Enumerize** base model.

(It was while adding Enumerize support to **[The Brick](https://github.com/lorint/brick)** that I'd seen this issue, and coded this [solution](https://github.com/lorint/brick/commit/b100dcd42159d689d92678f317430f35e3d58618).)