### PR TITLE
Revert "Require rspec instead of only expectations to fix load issue …

### DIFF
--- a/lib/enumerize.rb
+++ b/lib/enumerize.rb
@@ -82,7 +82,7 @@ module Enumerize
   end
 
   begin
-    require 'rspec'
+    require 'rspec/matchers'
   rescue LoadError
   else
     require 'enumerize/integrations/rspec'


### PR DESCRIPTION
This reverts commit 28dd2247ec03ef9a7e74266060d443ed8df1c2b4.

This fixes #425 for my specific test that was failing when upgrading to 2.6.1

I don't know what the load issue this was intended to fix, so this might cause problems for others. 