### PR TITLE
Allows the original options specified in enumerize to be retrieved from Enumerize::Attribute.

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -2,7 +2,7 @@
 
 module Enumerize
   class Attribute
-    attr_reader :klass, :name, :values, :default_value, :i18n_scope, :skip_validations_value
+    attr_reader :klass, :name, :values, :default_value, :i18n_scope, :skip_validations_value, :origin_options
 
     def initialize(klass, name, options={})
       raise ArgumentError, ':in option is required' unless options[:in]
@@ -13,6 +13,7 @@ module Enumerize
       @klass  = klass
       @name   = name.to_sym
       @i18n_scope = options[:i18n_scope]
+      @origin_options = options
 
       value_class = options.fetch(:value_class, Value)
       @values = Array(options[:in]).map { |v| value_class.new(self, *v).freeze }

--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -2,7 +2,7 @@
 
 module Enumerize
   class Attribute
-    attr_reader :klass, :name, :values, :default_value, :i18n_scope, :skip_validations_value, :origin_options
+    attr_reader :klass, :name, :values, :default_value, :i18n_scope, :skip_validations_value, :arguments
 
     def initialize(klass, name, options={})
       raise ArgumentError, ':in option is required' unless options[:in]
@@ -13,7 +13,7 @@ module Enumerize
       @klass  = klass
       @name   = name.to_sym
       @i18n_scope = options[:i18n_scope]
-      @origin_options = options
+      @arguments = options
 
       value_class = options.fetch(:value_class, Value)
       @values = Array(options[:in]).map { |v| value_class.new(self, *v).freeze }

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -42,7 +42,7 @@ class AttributeTest < MiniTest::Spec
   describe 'origin options' do
     it 'returns original options' do
       build_attr nil, :foo, :in => [:a, :b], :scope => true
-      expect(attr.origin_options).must_equal({:is => [:a, :b], :scope => true})
+      expect(attr.origin_options).must_equal({:in => [:a, :b], :scope => true})
     end
   end
 

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -39,6 +39,13 @@ class AttributeTest < MiniTest::Spec
     end
   end
 
+  describe 'origin options' do
+    it 'returns original options' do
+      build_attr nil, :foo, :in => [:a, :b], :scope => true
+      expect(attr.origin_options).must_equal({:is => [:a, :b], :scope => true})
+    end
+  end
+
   describe 'options for select' do
     it 'returns all options for select' do
       store_translations(:en, :enumerize => {:foo => {:a => 'a text', :b => 'b text'}}) do

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -39,10 +39,10 @@ class AttributeTest < MiniTest::Spec
     end
   end
 
-  describe 'origin options' do
-    it 'returns original options' do
+  describe 'arguments' do
+    it 'returns arguments' do
       build_attr nil, :foo, :in => [:a, :b], :scope => true
-      expect(attr.origin_options).must_equal({:in => [:a, :b], :scope => true})
+      expect(attr.arguments).must_equal({:in => [:a, :b], :scope => true})
     end
   end
 


### PR DESCRIPTION
This allows you to get the options specified by enumerize from an instance of Enumerize::Attribute.
I would like to use this to help create a DSL Compiler for [Tapioca](https://github.com/Shopify/tapioca).