### PR TITLE
Added environment variable MT_COMPAT for Minitest 5.19.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -73,3 +73,4 @@ jobs:
         POSTGRES_USER: postgres
         POSTGRES_PASSWORD: postgres
         MYSQL_ROOT_PASSWORD: mysql
+        MT_COMPAT: 1


### PR DESCRIPTION
The GitHub Actions test may be failing due to the absence of the environment variable MT_COMPAT, which was added in Minitest 5.19.

https://github.com/minitest/minitest/blob/ed88d196bc5dde30d48026ef7b338997b640e799/History.rdoc#L6

This fix would not resolve the 'uninitialized constant Mongoid::Railties::ActiveJobSerializers::ActiveJob (NameError)'.