### PR TITLE
Properly serialize boolean values.

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -110,16 +110,14 @@ module Enumerize
 
       def serialize(value)
         v = @attr.find_value(value)
-        (v && v.value) || value
-      end
+        return value unless v
 
-      alias type_cast_for_database serialize
+        v.value
+      end
 
       def cast(value)
         @attr.find_value(value)
       end
-
-      alias type_cast_from_database cast
 
       def as_json(options = nil)
         {attr: @attr.name}.as_json(options)


### PR DESCRIPTION
This fixes a bug where the value of a `false` boolean attribute was not properly serialized because it was treated as ruby's `false` in condition and that condition was never met.

Fixes https://github.com/brainspec/enumerize/issues/430