### PR TITLE
Properly deserialize boolean values

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -20,6 +20,15 @@ module Enumerize
 
       @value_hash = Hash[@values.map { |v| [v.value.to_s, v] }]
       @value_hash.merge! Hash[@values.map { |v| [v.to_s, v] }]
+      # boolean values are represented as 0 and 1 in the database
+      @values.each do |v|
+        case v.value
+        when true
+          @value_hash['1'] = v
+        when false
+          @value_hash['0'] = v
+        end
+      end
 
       if options[:default]
         @default_value = find_default_value(options[:default])

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -664,9 +664,11 @@ class ActiveRecordTest < Minitest::Spec
 
     User.create!(newsletter_subscribed: true)
     expect(User.exists?(newsletter_subscribed: true)).must_equal true
+    expect(User.where(newsletter_subscribed: true).take.newsletter_subscribed).must_equal 'subscribed'
 
     User.create!(newsletter_subscribed: false)
     expect(User.exists?(newsletter_subscribed: false)).must_equal true
+    expect(User.where(newsletter_subscribed: false).take.newsletter_subscribed).must_equal 'unsubscribed'
   end
 
 


### PR DESCRIPTION
A boolean field was nil after retrieving it from the DB where it should have a value. Fixed so that the value can be retrieved in this PR. If you comment out this change, you can see that it is `nil` in the added test case.

In the test case `'supports boolean column as enumerized field'` in file test/activerecord_test.rb, the `@attr` in `Enumerize::ActiveRecordSupport::Type#cast` looked like this.

In the test case, when `Enumerize::ActiveRecordSupport::Type#cast` was called, the `@attr` looked like this.

```ruby
...
@value_hash={"true"=>"subscribed", "false"=>"unsubscribed", "subscribed"=>"subscribed", "unsubscribed"=>"unsubscribed"}
...
```

The actual `value` is `'0'` or `'1'` at the time it is retrieved from the DB. The result was `nil` because the key of `@attr` did not contain them.
