### PR TITLE
Make Enumerize::Value#as_json return a string. not an instance of Enumerize::Value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix a bug where the value of a false boolean attribute was not properly serialized because it was
   treated as ruby's false in condition and that condition was never met. (by [@nashby](https://github.com/nashby))
+* Make `Enumerize::Value#as_json` return a string, not an instance of `Enumerize::Value` (by [@nashby](https://github.com/nashby))
 
 ### enchancements
 
@@ -17,7 +18,7 @@
 * Warn about already defined predicate methods only when we generate predicate methods with `predicate: true` (by [@nashby](https://github.com/nashby))
 * Define `Type#cast` instead of deserialize to fix serialization issue. (by [@nashby](https://github.com/nashby))
 * Fix `Undefined method 'enumerize' for RSpec::ExampleGroups` (by [@softwaregravy](https://github.com/softwaregravy))
-  
+
 ### enchancements
 
 * Add support for procs as `i18n_scope` option value. (by [@nashby](https://github.com/nashby))

--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -38,6 +38,10 @@ module Enumerize
       coder.represent_object(self.class.superclass, @value)
     end
 
+    def as_json(*)
+      to_s
+    end
+
     private
 
     def predicate_call(value)

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -162,4 +162,11 @@ class ValueTest < Minitest::Spec
       assert_silent() { Enumerize::Value.new(attr, 'test_value') }
     end
   end
+
+  describe '#as_json' do
+    it 'returns String object, not Value object' do
+      expect(val.as_json.class).must_equal String
+      expect(val.as_json).must_equal 'test_value'
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/brainspec/enumerize/issues/436