### PR TITLE
Fix attribute type cast for duplicated record.

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -122,7 +122,11 @@ module Enumerize
       end
 
       def cast(value)
-        @attr.find_value(@subtype.cast(value))
+        if value.is_a?(::Enumerize::Value)
+          value
+        else
+          @attr.find_value(@subtype.cast(value))
+        end
       end
 
       def as_json(options = nil)

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -668,6 +668,18 @@ class ActiveRecordTest < Minitest::Spec
     expect(User.find_by(newsletter_subscribed: false).newsletter_subscribed).must_equal 'unsubscribed'
   end
 
+  it 'has same value with original object when created by #dup' do
+    user1 = User.new(skill: :casual)
+    user2 = user1.dup
+    expect(user2.skill).must_equal 'casual'
+  end
+
+  it 'has same value with original object when created by #clone' do
+    user1 = User.new(skill: :casual)
+    user2 = user1.clone
+    expect(user2.skill).must_equal 'casual'
+  end
+
   if Rails::VERSION::MAJOR >= 6
     it 'supports AR#insert_all' do
       User.delete_all


### PR DESCRIPTION
## Problem

The minimum code to reproduce the bug is as follows

```ruby
class Foo < ActiveRecord::Base
  enumerize :bar, :in => { a: 0, b: 1 }
end

foo1 = Foo.new(bar: :b)
foo2 = foo1.dup

foo2.bar
=> "a"
```

`foo2.bar` should be `"b"` but was actually `"a"`.

If a copy is made by `dup`, `foo2.attributes_before_type_cast["bar"]` will hold `"b"`(Enumerize::Value) instead of `1`(Integer). If the argument `value` of `Enumerize::ActiveRecordSupport::Type#cast` is `"b"`(Enumerize::Value), `@subtype.cast(value)` will return `0(Integer)`. This is probably because `"b".to_i` is `0`. Therefore, `@attr.find_value(0)` returns `"a"`(Enumerize::Value).

On the master branch, the test for the `#dup` I just added will fail.

## Fixes

If the argument `value` of `Enumerize::ActiveRecordSupport::Type#cast` is Enumerize::Value, it is returned as is.