### PR TITLE
fix: enumerize with string store accessor keys

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -78,7 +78,7 @@ module Enumerize
           begin
             # Checks first if the enumerized attribute is in ActiveRecord::Store
             store_attr, _ = reloaded.class.stored_attributes.detect do |_store_attr, keys|
-              keys.include?(attr.name)
+              keys.map(&:to_sym).include?(attr.name.to_sym)
             end
 
             if store_attr.present?

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -108,10 +108,11 @@ class User < ActiveRecord::Base
   extend Enumerize
   include RoleEnum
 
-  store :settings, accessors: [:language]
+  store :settings, accessors: [:language, 'country_code']
 
   enumerize :sex, :in => [:male, :female], scope: :shallow
   enumerize :language, :in => [:en, :jp]
+  enumerize :country_code, :in => [:us, :ca]
 
   serialize :interests, type: Array
   enumerize :interests, :in => [:music, :sports, :dancing, :programming], :multiple => true
@@ -209,6 +210,15 @@ class ActiveRecordTest < Minitest::Spec
     user.reload
     expect(user.store_accessor_store_with_no_defaults).must_be_nil
     expect(user.origin).must_be_nil
+  end
+
+  it 'saves stored attribute value for store accessor with string key' do
+    User.delete_all
+    user = User.new
+    user.country_code = :us
+    user.save!
+    user.reload
+    expect(user.country_code).must_equal 'us'
   end
 
   it 'has default value' do


### PR DESCRIPTION
Ensures Enumerize is agnostic to whether the key to a store accessor is a string or symbol.

Re-opening https://github.com/brainspec/enumerize/pull/405 but with fix to not generate string objects with `#to_s` from original PR. Because ActiveRecord::Store's `.store` and `.store_accessor` methods allow string names for attribute names, we should be able to handle them. This has come up for me when dealing with meta-programming where one dynamically defines store attributes.