### PR TITLE
Support enumerization of the same attribute in child class.

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -124,6 +124,8 @@ module Enumerize
       end
 
       def cast(value)
+        return value if @subtype.is_a?(Type)
+
         if value.is_a?(::Enumerize::Value)
           value
         else

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -693,6 +693,15 @@ class ActiveRecordTest < Minitest::Spec
     expect(user2.skill).must_equal 'casual'
   end
 
+  it 'works when child class calls enumerize second time' do
+    class AdminUser < User
+      enumerize :account_type, in: [:basic, :premium, :pro]
+    end
+
+    admin = AdminUser.create(account_type: 'pro')
+    expect(admin.account_type).must_equal 'pro'
+  end
+
   if Rails::VERSION::MAJOR >= 6
     it 'supports AR#insert_all' do
       User.delete_all


### PR DESCRIPTION
Typical use case of this is:

```ruby
class User < ActiveRecord::Base
  enumerize :role, in: [:user]
end

class Admin < User
  enumerize :role, in: [:user, :admin]
end
```

So if we want to redefine enumerized field in a child class we call `enumerize` again and that's causes issue since we try to decorate this `role` field again and when we try to `cast` given value we end up with calling `cast` on enumerized `Type` object but for already decorated attribute we just want to return its plain value, not a casted one.