### PR TITLE
Add failing test cases for ActiveRecord#normalizes

### DIFF
--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -759,7 +759,6 @@ class ActiveRecordTest < Minitest::Spec
     expect(User.exists?(interests: [:music, :sports])).must_equal true
   end
 
-  # Commenting out `normalizes :locale, ...` will make these tests green
   it 'supports AR#normalizes class methods' do
     User.delete_all
     User.create!(locale: 'de')


### PR DESCRIPTION
See #459 - enumerize does currently not work together with `normalizes` from ActiveRecord.