### PR TITLE
Fix minor Ruby warnings

### DIFF
--- a/lib/enumerize/attribute.rb
+++ b/lib/enumerize/attribute.rb
@@ -90,6 +90,7 @@ module Enumerize
 
     def define_methods!(mod)
       mod.module_eval <<-RUBY, __FILE__, __LINE__ + 1
+        alias_method "#{name}", "#{name}" if method_defined?("#{name}")
         def #{name}
           if defined?(super)
             self.class.enumerized_attributes[:#{name}].find_value(super)
@@ -104,6 +105,7 @@ module Enumerize
           end
         end
 
+        alias_method "#{name}=", "#{name}=" if method_defined?("#{name}=")
         def #{name}=(new_value)
           allowed_value_or_nil = self.class.enumerized_attributes[:#{name}].find_value(new_value)
           allowed_value_or_nil = allowed_value_or_nil.value unless allowed_value_or_nil.nil?
@@ -121,10 +123,12 @@ module Enumerize
           allowed_value_or_nil
         end
 
+        alias_method "#{name}_text", "#{name}_text" if method_defined?("#{name}_text")
         def #{name}_text
           self.#{name} && self.#{name}.text
         end
 
+        alias_method "#{name}_value", "#{name}_value" if method_defined?("#{name}_value")
         def #{name}_value
           self.#{name} && self.#{name}.value
         end


### PR DESCRIPTION
The gem produces a lot of runtime warnings when running with `-W`:

```bash
enumerize-2.8.1/lib/enumerize/attribute.rb:93: warning: method redefined; discarding old <enumerize-attr>
enumerize-2.8.1/lib/enumerize/attribute.rb:93: warning: previous definition of <enumerize-attr>
enumerize-2.8.1/lib/enumerize/attribute.rb:107: warning: method redefined; discarding <enumerize-attr>
enumerize-2.8.1/lib/enumerize/attribute.rb:107: warning: previous definition of <enumerize-attr> was here
enumerize-2.8.1/lib/enumerize/attribute.rb:124: warning: method redefined; discarding old <enumerize-attr>
enumerize-2.8.1/lib/enumerize/attribute.rb:124: warning: previous definition of <enumerize-attr> was here
enumerize-2.8.1/lib/enumerize/attribute.rb:128: warning: method redefined; discarding old <enumerize-attr>
```

it seems reasonable to use the self-alias trick to suppress them. WDYT?