### PR TITLE
FIX: Enumerize::Value to handle callable i18n_scope dynamically

### DIFF
--- a/lib/enumerize/value.rb
+++ b/lib/enumerize/value.rb
@@ -15,19 +15,22 @@ module Enumerize
 
       super(name.to_s)
 
-      @i18n_keys = @attr.i18n_scopes.map do |s|
+      @default_i18n_keys = []
+      @default_i18n_keys << :"enumerize.defaults.#{@attr.name}.#{self}"
+      @default_i18n_keys << :"enumerize.#{@attr.name}.#{self}"
+      @default_i18n_keys << ActiveSupport::Inflector.humanize(ActiveSupport::Inflector.underscore(self)) # humanize value if there are no translations
+    end
+
+    def i18n_keys
+      @attr.i18n_scopes.map do |s|
         scope = Utils.call_if_callable(s, @value)
 
         :"#{scope}.#{self}"
-      end
-      @i18n_keys << :"enumerize.defaults.#{@attr.name}.#{self}"
-      @i18n_keys << :"enumerize.#{@attr.name}.#{self}"
-      @i18n_keys << ActiveSupport::Inflector.humanize(ActiveSupport::Inflector.underscore(self)) # humanize value if there are no translations
-      @i18n_keys
+      end.push(*@default_i18n_keys)
     end
 
     def text
-      I18n.t(@i18n_keys[0], :default => @i18n_keys[1..-1]) if @i18n_keys
+      I18n.t(i18n_keys[0], :default => i18n_keys[1..-1])
     end
 
     def ==(other)

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -95,6 +95,37 @@ class ValueTest < Minitest::Spec
         expect(val.text).must_be :==, "Scope specific translation"
       end
     end
+
+    context 'allows to pass a proc as i18n_scopes param with dynamic scope' do
+      let(:translations) do
+        [:en, :other => {:scope => {:"foo" => {:test_value => "Foo translation"}, :"bar" => {:test_value => "Bar translation"}}}]
+      end
+
+      before do
+        @value = nil
+        attr.i18n_scopes = [proc { "other.scope.#{@value}" }, :"other.scope.foo"]
+      end
+
+      it 'returns default with nil value' do
+        store_translations(translations) do
+          expect(val.text).must_be :==, "Foo translation"
+        end
+      end
+
+      it 'returns foo translation with foo value' do
+        store_translations(translations) do
+          @value = "foo"
+          expect(val.text).must_be :==, "Foo translation"
+        end
+      end
+
+      it 'returns bar translation with bar value' do
+        store_translations(translations) do
+          @value = "bar"
+          expect(val.text).must_be :==, "Bar translation"
+        end
+      end
+    end
   end
 
   describe 'boolean methods comparison' do


### PR DESCRIPTION
To handle contextual local with `proc`
Ex: 
```ruby
    enumerize :license_type,
      in: [:student, :teacher, :user],
      i18n_scope: [
        -> { "enum.license_type/#{Current.application_platform}" },
        "models.article.enum.targets"
      ],
      scope: true,
      predicates: true
```

locales/enumerize.fr.yml
```yml
fr:
  enum:
    license_type: &license_types
      student: Élève
      teacher: Enseignant
      user: Particulier

    license_type/academic:
      <<: *license_types

    license_type/other:
      teacher: Enseignant
      student: Apprenant
```

Expect:
```ruby
Current.application_platform = nil
Article.license_type.values["student"] # => "Élève"

Current.application_platform = :academic
Article.license_type.values["student"] # => "Élève"

Current.application_platform = :other
Article.license_type.values["student"] # => "Apprenant"
```