### PR TITLE
Update GitHub Actions runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -50,6 +50,8 @@ jobs:
           - ruby-version: '3.1'
             gemfile: Gemfile.mongo_mapper
           - ruby-version: '3.1'
+            gemfile: Gemfile.rails80
+          - ruby-version: '3.1'
             gemfile: Gemfile.railsmaster
     env:
       BUNDLE_GEMFILE: "${{ matrix.gemfile }}"


### PR DESCRIPTION
Change to `ubuntu-24.04` since `ubuntu-20.04` is not supported in the current GitHub Acions.

Also, Rails 8.0 doesn't support Ruby 3.1.

See also: 
- https://github.com/actions/runner-images/pull/11748
