### PR TITLE
Fix Type#cast for Rails 8.0 insert_all/upsert_all compatibility

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -127,7 +127,14 @@ module Enumerize
         if value.is_a?(::Enumerize::Value)
           value
         else
-          @attr.find_value(@subtype.cast(value))
+          enumerize_value = @attr.find_value(value)
+          
+          if enumerize_value
+            enumerize_value
+          else
+            casted = @subtype.cast(value)
+            @attr.find_value(casted)
+          end
         end
       end
 

--- a/test/activerecord_test.rb
+++ b/test/activerecord_test.rb
@@ -754,4 +754,106 @@ class ActiveRecordTest < Minitest::Spec
     expect(User.exists?(status: :active)).must_equal true
     expect(User.exists?(interests: [:music, :sports])).must_equal true
   end
+
+  it 'Type#cast returns Enumerize::Value for symbols' do
+    type = User.type_for_attribute('status')
+    result = type.cast(:active)
+    
+    expect(result).must_be_instance_of Enumerize::Value
+    expect(result.to_s).must_equal 'active'
+    expect(result.value).must_equal 1
+  end
+
+  it 'Type#cast returns Enumerize::Value for integers' do
+    type = User.type_for_attribute('status')
+    result = type.cast(1)
+    
+    expect(result).must_be_instance_of Enumerize::Value
+    expect(result.to_s).must_equal 'active'
+    expect(result.value).must_equal 1
+  end
+
+  it 'Type#cast returns Enumerize::Value for string keys' do
+    type = User.type_for_attribute('status')
+    result = type.cast('active')
+    
+    expect(result).must_be_instance_of Enumerize::Value
+    expect(result.to_s).must_equal 'active'
+    expect(result.value).must_equal 1
+  end
+
+  it 'Type#cast returns nil for invalid values' do
+    type = User.type_for_attribute('status')
+    result = type.cast(:invalid)
+    
+    expect(result).must_be_nil
+  end
+
+  it 'Type#cast preserves existing Enumerize::Value objects' do
+    type = User.type_for_attribute('status')
+    original_value = User.enumerized_attributes[:status].find_value(:active)
+    result = type.cast(original_value)
+    
+    expect(result).must_equal original_value
+  end
+
+  it 'insert_all with mixed value types works correctly' do
+    User.delete_all
+
+    User.insert_all([
+      { sex: :male, status: :active },
+      { sex: 'female', status: 2 },
+      { sex: :male, status: 'blocked' }
+    ])
+
+    users = User.all.to_a
+    expect(users.size).must_equal 3
+    
+    expect(users[0].sex).must_equal 'male'
+    expect(users[0].status).must_equal 'active'
+    
+    expect(users[1].sex).must_equal 'female'
+    expect(users[1].status).must_equal 'blocked'
+    
+    expect(users[2].sex).must_equal 'male'
+    expect(users[2].status).must_equal 'blocked'
+  end
+
+  it 'insert_all handles invalid enum values gracefully' do
+    User.delete_all
+
+    User.insert_all([
+      { sex: :invalid_sex, status: 999 }  # Use invalid integer for status
+    ])
+
+    user = User.first
+    expect(user.sex).must_be_nil
+    expect(user.status).must_be_nil
+  end
+
+  it 'upsert_all with different value formats works correctly' do
+    User.delete_all
+
+    User.upsert_all([
+      { id: 1, sex: :male, status: 1 },
+      { id: 2, sex: 'female', status: :blocked }
+    ])
+
+    User.upsert_all([
+      { id: 1, sex: 'male', status: :active },
+      { id: 3, sex: :female, status: 2 }
+    ])
+
+    users = User.order(:id).to_a
+    expect(users.size).must_equal 3
+    
+    expect(users[0].sex).must_equal 'male'
+    expect(users[0].status).must_equal 'active'
+    
+    expect(users[1].sex).must_equal 'female'
+    expect(users[1].status).must_equal 'blocked'
+    
+    expect(users[2].sex).must_equal 'female'
+    expect(users[2].status).must_equal 'blocked'
+  end
 end


### PR DESCRIPTION
## Fix Rails 8.0 bulk operations (insert_all/upsert_all) for enumerized attributes

### Summary

This PR fixes an issue where enumerized attributes with Hash-based mappings (e.g., `status: { active: 1, blocked: 2 }`) are not correctly saved when using Rails 8.0's bulk operation methods (`insert_all`, `insert_all!`, `upsert_all`).

Fixes #[issue_number] (if applicable)

### Problem

In Rails 8.0, the type casting behavior for bulk operations has become more strict. When using `insert_all` or `upsert_all` with enumerized attributes that map symbols/strings to integers:

**Before (Rails 7.x):**
```ruby
User.insert_all([{ status: :active }])
# => Saved as "active" (string) - worked by accident due to lenient type casting
```

**After (Rails 8.0):**
```ruby
User.insert_all([{ status: :active }])
# => Saved as nil - symbol cannot be cast to integer, results in nil
```

This happens because:
1. Rails 8.0 enforces stricter type validation in bulk operations (see [rails/rails#53511](https://github.com/rails/rails/pull/53511) which introduced `ActiveModel::Type::SerializeCastValue` for type casting in `InsertAll`)
2. Bulk operations bypass ActiveRecord instantiation, preventing Enumerize's type system from converting symbols to their database values
3. The `Type#cast` method was not properly handling the conversion when called directly by Rails' bulk operations

### Solution

This PR improves the `Enumerize::ActiveRecordSupport::Type#cast` method to properly handle value conversion in all contexts, including Rails 8.0's bulk operations.

The fix ensures that:
1. Direct symbol/string values are first checked against enumerize values
2. If not found directly, the value is cast by the underlying type and then checked again
3. This maintains compatibility with both regular operations and bulk operations

### Changes

- Modified `lib/enumerize/activerecord.rb`: Improved `Type#cast` method to handle direct value lookup before delegating to subtype
- Added comprehensive tests in `test/activerecord_test.rb` covering:
  - Type casting with symbols, integers, and strings
  - `insert_all` with mixed value types
  - `upsert_all` with different value formats
  - Graceful handling of invalid enum values

### Impact

- **Fixes:** Rails 8.0 bulk operations now correctly save enumerized values
- **Backwards Compatible:** No breaking changes for Rails 7.x or earlier
- **Minimal Change:** Small, focused fix that doesn't alter existing behavior
- **Performance:** No performance impact on regular operations

### Testing

All tests pass on:
- Rails 7.0, 7.1, 8.0
- SQLite3, PostgreSQL, MySQL
- Ruby 3.1+

```bash
# Run tests with Rails 8.0
BUNDLE_GEMFILE=Gemfile.rails80 DB=sqlite3 bundle exec rake

# Run specific bulk operation tests
BUNDLE_GEMFILE=Gemfile.rails80 DB=sqlite3 bundle exec ruby -Itest test/activerecord_test.rb -n "/insert_all|upsert_all/"
```

### Examples

**After this fix:**
```ruby
# Define enumerized attribute with integer mapping
class User < ApplicationRecord
  extend Enumerize
  enumerize :status, in: { active: 1, blocked: 2 }
end

# All these now work correctly in Rails 8.0:
User.insert_all([
  { status: :active },     # Symbol → saves as 1
  { status: 'active' },    # String → saves as 1  
  { status: 1 }           # Integer → saves as 1
])

User.upsert_all([
  { id: 1, status: :blocked }  # Works correctly
])
```

### Note for Maintainers

**I would appreciate your review particularly on whether this approach aligns with Enumerize's design philosophy.** While I believe improving the `Type#cast` method is less invasive than overriding bulk operation methods, I want to ensure this solution:

1. Maintains the principle of least surprise for users
2. Doesn't introduce unintended side effects in edge cases
3. Aligns with how you envision Enumerize integrating with ActiveRecord's type system

Please let me know if you prefer a different approach or if there are any design considerations I should be aware of.

### Checklist

- [x] Tests added for the bug fix
- [x] All existing tests pass
- [x] Tested against Rails 7.0, 7.1, and 8.0
- [x] Tested with SQLite3, PostgreSQL, and MySQL
- [x] No breaking changes introduced
- [x] Code follows the project's style conventions

Thank you for maintaining this excellent gem! Please let me know if you need any additional information or changes.