### PR TITLE
Support Rails normalizes method and fix empty string handling consistency

### DIFF
--- a/lib/enumerize/activerecord.rb
+++ b/lib/enumerize/activerecord.rb
@@ -115,10 +115,19 @@ module Enumerize
       end
 
       def serialize(value)
-        v = @attr.find_value(value)
-        return value unless v
+        # First try to find the enumerize value directly
+        enumerize_value = @attr.find_value(value)
 
-        v.value
+        # If not found and we have a subtype, delegate to it for transformation
+        # (e.g., normalization) and try again
+        if !enumerize_value && @subtype
+          casted_value = @subtype.cast(value)
+          enumerize_value = @attr.find_value(casted_value)
+        end
+
+        return value unless enumerize_value
+
+        enumerize_value.value
       end
 
       def cast(value)
@@ -127,10 +136,15 @@ module Enumerize
 
         # First try to find the enumerize value directly
         enumerize_value = @attr.find_value(value)
-        return enumerize_value if enumerize_value
 
-        # If not found, delegate to subtype then try to find value
-        @attr.find_value(@subtype.cast(value))
+        # If not found and we have a subtype, delegate to it for transformation
+        # (e.g., normalization) and try again
+        if !enumerize_value && @subtype
+          casted_value = @subtype.cast(value)
+          enumerize_value = @attr.find_value(casted_value)
+        end
+
+        enumerize_value
       end
 
       def as_json(options = nil)


### PR DESCRIPTION
## Motivation / Background

This Pull Request enhances Enumerize to properly support Rails 7.1+ `normalizes` method and addresses empty string handling consistency across ORMs.

## Detail

### Rails Normalizes Integration

Rails 7.1 introduced the `normalizes` method for attribute normalization:
```ruby
normalizes :locale, with: ->(value) { value.downcase.strip.presence }
enumerize :locale, in: [:de, :en, :pl]
```

The existing `Type#cast` and `Type#serialize` methods didn't properly delegate to subtypes for normalization. This prevented normalized values from being correctly matched against enum values, causing enum validation to fail even when the normalized value was valid.

For example, with the above configuration, setting `locale = " DE "` should normalize to `"de"` and match the `:de` enum value, but this wasn't working properly.

Fixes #459 

### Empty String Handling Consistency

Additionally, Enumerize exhibited inconsistent behavior when handling empty strings across various ORMs:
- ActiveRecord: Implicitly converted empty strings to `nil`
- Sequel/Others: Stored empty strings as `""`

This inconsistency led to failing tests, specifically: `"stores nil when empty string assigned"` in SequelTest.

## Solution

### 1. Enhanced Type Casting for Normalization Support

Updated `lib/enumerize/activerecord.rb` to properly handle value transformation through subtypes:

```ruby
def cast(value)
  return value if value.is_a?(::Enumerize::Value)

  # First try direct lookup
  enumerize_value = @attr.find_value(value)

  # If not found and we have a subtype, delegate for transformation (e.g., normalization)
  if !enumerize_value && @subtype
    casted_value = @subtype.cast(value)
    enumerize_value = @attr.find_value(casted_value)
  end

  enumerize_value
end
```

Similar logic was applied to the `serialize` method to ensure consistent behavior during database operations.

### 2. Explicit Empty String Conversion

Modified `lib/enumerize/attribute.rb` to explicitly convert empty strings to `nil` in the attribute setter:

```ruby
def #{name}=(new_value)
  allowed_value = self.class.enumerized_attributes[:#{name}].find_value(new_value)

  value_to_assign = if allowed_value
    allowed_value.value
  elsif new_value == ''
    nil  # Explicit conversion for consistency across ORMs
  else
    new_value
  end
  # ...
end
```

This ensures consistent behavior across all ORMs, eliminating the discrepancy between ActiveRecord and other ORMs like Sequel.
