### PR TITLE
Fix Type#deserialize to handle arrays for multiple: true attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### bug fix
 
+* Fixed `Enumerize::ActiveModelAttributesSupport::Type#deserialize` to properly handle arrays for `multiple: true` attributes. Previously, deserializing an array would return `nil` instead of the enumerated values. This bug only affected ActiveModel::Attributes usage (not ActiveRecord) and was exposed when used with gems like store_model v2.0.0+ that call `deserialize` during load.
+
 ### enchancements
 
 * Support only Ruby 3.1+ and Rails 7.0+. (by [@nashby](https://github.com/nashby))

--- a/lib/enumerize/activemodel.rb
+++ b/lib/enumerize/activemodel.rb
@@ -40,7 +40,15 @@ module Enumerize
       end
 
       def deserialize(value)
-        @attr.find_value(value)
+        return nil if value.nil?
+
+        # Use find_values for arrays on multiple: true attributes
+        # Otherwise use find_value for single values
+        if value.is_a?(Array) && @attr.arguments[:multiple]
+          @attr.find_values(*value)
+        else
+          @attr.find_value(value)
+        end
       end
     end
   end


### PR DESCRIPTION
Previously, deserializing an array would return nil instead of the enumerated values. This bug only affected ActiveModel::Attributes usage (not ActiveRecord) and was exposed when used with gems like store_model v2.0.0+ that call deserialize during load.

The fix checks if the value is an array AND the attribute is declared with multiple: true, then uses find_values(*value) instead of find_value(value).

Added 10 test cases covering:
- Single value deserialization (existing behavior)
- Array deserialization for multiple: true attributes
- Array rejection for non-multiple attributes
- Empty arrays, nil handling, and invalid value filtering
- Round-trip serialization for both single and multiple values